### PR TITLE
fix: #1 — chore(foundation): Go skeleton, CI, and verse schema

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+          cache: true
+      - name: go vet
+        run: go vet ./...
+      - name: staticcheck
+        run: |
+          go install honnef.co/go/tools/cmd/staticcheck@latest
+          staticcheck ./...
+      - name: go test
+        run: go test ./...

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+bin/
+*.exe
+*.test
+*.out
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+.PHONY: build test lint vet staticcheck tidy clean all
+
+BINARY := scripture-mcp
+CMD := ./cmd/scripture-mcp
+BUILD_DIR := bin
+
+all: lint test build
+
+build:
+	mkdir -p $(BUILD_DIR)
+	go build -o $(BUILD_DIR)/$(BINARY) $(CMD)
+
+test:
+	go test ./...
+
+vet:
+	go vet ./...
+
+staticcheck:
+	@command -v staticcheck >/dev/null 2>&1 || go install honnef.co/go/tools/cmd/staticcheck@latest
+	staticcheck ./...
+
+lint: vet staticcheck
+
+tidy:
+	go mod tidy
+
+clean:
+	rm -rf $(BUILD_DIR)

--- a/cmd/scripture-mcp/main.go
+++ b/cmd/scripture-mcp/main.go
@@ -1,0 +1,9 @@
+package main
+
+import "fmt"
+
+const Version = "v0.0.0"
+
+func main() {
+	fmt.Printf("scripture-mcp %s\n", Version)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/MiaoDX/verse-driven
+
+go 1.24.7

--- a/internal/cli/doc.go
+++ b/internal/cli/doc.go
@@ -1,0 +1,2 @@
+// Package cli implements the lookup / recap / init subcommands. Lands in issue #4.
+package cli

--- a/internal/injector/doc.go
+++ b/internal/injector/doc.go
@@ -1,0 +1,3 @@
+// Package injector renders the temporary, one-turn scripture envelope
+// described in plan.md §6.3. Implementation lands when adapters wire it up.
+package injector

--- a/internal/mcp/doc.go
+++ b/internal/mcp/doc.go
@@ -1,0 +1,2 @@
+// Package mcp implements the stdio MCP server. Lands in issue #4.
+package mcp

--- a/internal/packs/doc.go
+++ b/internal/packs/doc.go
@@ -1,0 +1,3 @@
+// Package packs holds embedded verse data (KJV, 道德经, 心经, ...).
+// Pack contents are added in issue #3.
+package packs

--- a/internal/resolver/doc.go
+++ b/internal/resolver/doc.go
@@ -1,0 +1,3 @@
+// Package resolver parses free-form scripture references into canonical
+// (tradition, work, ref) tuples. Implementation lands in issue #2.
+package resolver

--- a/internal/schema/verse.go
+++ b/internal/schema/verse.go
@@ -1,0 +1,116 @@
+// Package schema defines the Verse contract that every pack must satisfy.
+// See plan.md §6.1 and internal/schema/verse.schema.json.
+package schema
+
+import (
+	_ "embed"
+	"errors"
+	"fmt"
+	"regexp"
+)
+
+//go:embed verse.schema.json
+var JSONSchema []byte
+
+type CanonicalRef struct {
+	Book       string `json:"book,omitempty"`
+	Chapter    int    `json:"chapter"`
+	VerseStart int    `json:"verse_start"`
+	VerseEnd   int    `json:"verse_end,omitempty"`
+}
+
+type Source struct {
+	Provider    string `json:"provider"`
+	License     string `json:"license"`
+	Attribution string `json:"attribution"`
+}
+
+type Verse struct {
+	ID             string            `json:"id"`
+	Tradition      string            `json:"tradition"`
+	Lang           string            `json:"lang"`
+	Work           string            `json:"work,omitempty"`
+	CanonicalRef   CanonicalRef      `json:"canonical_ref"`
+	DisplayRef     map[string]string `json:"display_ref,omitempty"`
+	Text           string            `json:"text"`
+	Source         Source            `json:"source"`
+	ChecksumSHA256 string            `json:"checksum_sha256"`
+	InclusionMode  string            `json:"inclusion_mode,omitempty"`
+	Sensitivity    string            `json:"sensitivity,omitempty"`
+}
+
+var (
+	ErrMissingID             = errors.New("verse: id is required")
+	ErrMissingTradition      = errors.New("verse: tradition is required")
+	ErrMissingLang           = errors.New("verse: lang is required")
+	ErrMissingText           = errors.New("verse: text is required")
+	ErrMissingCanonicalRef   = errors.New("verse: canonical_ref.chapter and canonical_ref.verse_start are required")
+	ErrMissingSource         = errors.New("verse: source.provider/license/attribution are required")
+	ErrMissingChecksum       = errors.New("verse: checksum_sha256 is required")
+	ErrBadChecksum           = errors.New("verse: checksum_sha256 must be 64 lowercase hex characters")
+	ErrBadID                 = errors.New("verse: id must be dotted lowercase, e.g. bible.kjv.john.3.16")
+	ErrBadInclusionMode      = errors.New("verse: inclusion_mode must be one of bundled, api_only")
+	ErrBadSensitivity        = errors.New("verse: sensitivity must be one of sacred_exact_quote")
+	ErrBadVerseRange         = errors.New("verse: verse_end must be >= verse_start when set")
+)
+
+var (
+	idPattern       = regexp.MustCompile(`^[a-z0-9]+(\.[a-z0-9]+)+$`)
+	checksumPattern = regexp.MustCompile(`^[0-9a-f]{64}$`)
+)
+
+var (
+	validInclusionModes = map[string]struct{}{
+		"bundled":  {},
+		"api_only": {},
+	}
+	validSensitivities = map[string]struct{}{
+		"sacred_exact_quote": {},
+	}
+)
+
+// Validate checks that v conforms to the verse schema.
+// Returns nil on success; returns the first violation encountered otherwise.
+func Validate(v Verse) error {
+	if v.ID == "" {
+		return ErrMissingID
+	}
+	if !idPattern.MatchString(v.ID) {
+		return fmt.Errorf("%w: %q", ErrBadID, v.ID)
+	}
+	if v.Tradition == "" {
+		return ErrMissingTradition
+	}
+	if v.Lang == "" {
+		return ErrMissingLang
+	}
+	if v.Text == "" {
+		return ErrMissingText
+	}
+	if v.CanonicalRef.Chapter < 1 || v.CanonicalRef.VerseStart < 1 {
+		return ErrMissingCanonicalRef
+	}
+	if v.CanonicalRef.VerseEnd != 0 && v.CanonicalRef.VerseEnd < v.CanonicalRef.VerseStart {
+		return ErrBadVerseRange
+	}
+	if v.Source.Provider == "" || v.Source.License == "" || v.Source.Attribution == "" {
+		return ErrMissingSource
+	}
+	if v.ChecksumSHA256 == "" {
+		return ErrMissingChecksum
+	}
+	if !checksumPattern.MatchString(v.ChecksumSHA256) {
+		return fmt.Errorf("%w: %q", ErrBadChecksum, v.ChecksumSHA256)
+	}
+	if v.InclusionMode != "" {
+		if _, ok := validInclusionModes[v.InclusionMode]; !ok {
+			return fmt.Errorf("%w: %q", ErrBadInclusionMode, v.InclusionMode)
+		}
+	}
+	if v.Sensitivity != "" {
+		if _, ok := validSensitivities[v.Sensitivity]; !ok {
+			return fmt.Errorf("%w: %q", ErrBadSensitivity, v.Sensitivity)
+		}
+	}
+	return nil
+}

--- a/internal/schema/verse.schema.json
+++ b/internal/schema/verse.schema.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/MiaoDX/verse-driven/internal/schema/verse.schema.json",
+  "title": "Verse",
+  "description": "A single verse entry. The contract every pack builder must satisfy. See plan.md §6.1.",
+  "type": "object",
+  "required": [
+    "id",
+    "tradition",
+    "lang",
+    "text",
+    "canonical_ref",
+    "source",
+    "checksum_sha256"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Stable dotted identifier, e.g. bible.kjv.john.3.16",
+      "pattern": "^[a-z0-9]+(\\.[a-z0-9]+)+$"
+    },
+    "tradition": {
+      "type": "string",
+      "description": "Tradition slug: bible, dao, sutra, quran, ...",
+      "minLength": 1
+    },
+    "lang": {
+      "type": "string",
+      "description": "BCP-47 language tag (en, zh-CN, ar, ...)",
+      "minLength": 2
+    },
+    "work": {
+      "type": "string",
+      "description": "Edition/translation identifier inside the tradition (KJV, daodejing, ...)"
+    },
+    "canonical_ref": {
+      "type": "object",
+      "description": "Normalized reference. book is optional for traditions that have only one work.",
+      "required": ["chapter", "verse_start"],
+      "additionalProperties": false,
+      "properties": {
+        "book": { "type": "string" },
+        "chapter": { "type": "integer", "minimum": 1 },
+        "verse_start": { "type": "integer", "minimum": 1 },
+        "verse_end": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "display_ref": {
+      "type": "object",
+      "description": "Per-language display strings, keyed by BCP-47 tag.",
+      "additionalProperties": { "type": "string" }
+    },
+    "text": {
+      "type": "string",
+      "description": "Verbatim verse text.",
+      "minLength": 1
+    },
+    "source": {
+      "type": "object",
+      "required": ["provider", "license", "attribution"],
+      "additionalProperties": false,
+      "properties": {
+        "provider": { "type": "string", "minLength": 1 },
+        "license": { "type": "string", "minLength": 1 },
+        "attribution": { "type": "string", "minLength": 1 }
+      }
+    },
+    "checksum_sha256": {
+      "type": "string",
+      "description": "Lowercase hex SHA-256 of the verse text bytes.",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "inclusion_mode": {
+      "type": "string",
+      "enum": ["bundled", "api_only"]
+    },
+    "sensitivity": {
+      "type": "string",
+      "enum": ["sacred_exact_quote"]
+    }
+  }
+}

--- a/internal/schema/verse_test.go
+++ b/internal/schema/verse_test.go
@@ -1,0 +1,118 @@
+package schema
+
+import (
+	"errors"
+	"testing"
+)
+
+func validVerse() Verse {
+	return Verse{
+		ID:        "bible.kjv.john.3.16",
+		Tradition: "bible",
+		Lang:      "en",
+		Work:      "KJV",
+		CanonicalRef: CanonicalRef{
+			Book:       "John",
+			Chapter:    3,
+			VerseStart: 16,
+			VerseEnd:   16,
+		},
+		DisplayRef: map[string]string{
+			"en":    "John 3:16",
+			"zh-CN": "约翰福音 3:16",
+		},
+		Text: "For God so loved the world, that he gave his only begotten Son...",
+		Source: Source{
+			Provider:    "Project Gutenberg",
+			License:     "public-domain-us",
+			Attribution: "KJV",
+		},
+		ChecksumSHA256: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		InclusionMode:  "bundled",
+		Sensitivity:    "sacred_exact_quote",
+	}
+}
+
+func TestValidate_HappyPath(t *testing.T) {
+	if err := Validate(validVerse()); err != nil {
+		t.Fatalf("expected valid verse, got: %v", err)
+	}
+}
+
+func TestValidate_MissingFields(t *testing.T) {
+	cases := []struct {
+		name  string
+		mut   func(*Verse)
+		wants error
+	}{
+		{"missing id", func(v *Verse) { v.ID = "" }, ErrMissingID},
+		{"missing tradition", func(v *Verse) { v.Tradition = "" }, ErrMissingTradition},
+		{"missing lang", func(v *Verse) { v.Lang = "" }, ErrMissingLang},
+		{"missing text", func(v *Verse) { v.Text = "" }, ErrMissingText},
+		{"missing chapter", func(v *Verse) { v.CanonicalRef.Chapter = 0 }, ErrMissingCanonicalRef},
+		{"missing verse_start", func(v *Verse) { v.CanonicalRef.VerseStart = 0 }, ErrMissingCanonicalRef},
+		{"missing source.provider", func(v *Verse) { v.Source.Provider = "" }, ErrMissingSource},
+		{"missing source.license", func(v *Verse) { v.Source.License = "" }, ErrMissingSource},
+		{"missing source.attribution", func(v *Verse) { v.Source.Attribution = "" }, ErrMissingSource},
+		{"missing checksum", func(v *Verse) { v.ChecksumSHA256 = "" }, ErrMissingChecksum},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			v := validVerse()
+			tc.mut(&v)
+			err := Validate(v)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !errors.Is(err, tc.wants) {
+				t.Fatalf("expected %v, got %v", tc.wants, err)
+			}
+		})
+	}
+}
+
+func TestValidate_BadEnumsAndFormats(t *testing.T) {
+	cases := []struct {
+		name  string
+		mut   func(*Verse)
+		wants error
+	}{
+		{"bad id format", func(v *Verse) { v.ID = "Bible/John/3:16" }, ErrBadID},
+		{"bad checksum hex", func(v *Verse) { v.ChecksumSHA256 = "not-a-hex-checksum" }, ErrBadChecksum},
+		{"short checksum", func(v *Verse) { v.ChecksumSHA256 = "abc123" }, ErrBadChecksum},
+		{"bad inclusion_mode", func(v *Verse) { v.InclusionMode = "remote" }, ErrBadInclusionMode},
+		{"bad sensitivity", func(v *Verse) { v.Sensitivity = "casual" }, ErrBadSensitivity},
+		{"verse_end before verse_start", func(v *Verse) {
+			v.CanonicalRef.VerseStart = 10
+			v.CanonicalRef.VerseEnd = 5
+		}, ErrBadVerseRange},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			v := validVerse()
+			tc.mut(&v)
+			err := Validate(v)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !errors.Is(err, tc.wants) {
+				t.Fatalf("expected %v, got %v", tc.wants, err)
+			}
+		})
+	}
+}
+
+func TestValidate_OptionalEnumsMayBeEmpty(t *testing.T) {
+	v := validVerse()
+	v.InclusionMode = ""
+	v.Sensitivity = ""
+	if err := Validate(v); err != nil {
+		t.Fatalf("optional enums should be allowed empty; got: %v", err)
+	}
+}
+
+func TestJSONSchemaEmbedded(t *testing.T) {
+	if len(JSONSchema) == 0 {
+		t.Fatal("expected verse.schema.json to be embedded")
+	}
+}


### PR DESCRIPTION
Closes #1.

Bootstraps the Go module, package layout, CI, and the verse data schema that every pack must satisfy.

## What's in this PR

- `go.mod` — module `github.com/MiaoDX/verse-driven`
- `cmd/scripture-mcp/main.go` — builds and prints `scripture-mcp v0.0.0`
- Directory skeleton: `internal/{packs,schema,resolver,mcp,cli,injector}` (each carries a `doc.go` so the package compiles and git tracks the dir)
- `internal/schema/verse.schema.json` — JSON Schema matching `plan.md` §6.1
- `internal/schema/verse.go` — Go `Verse` struct + `Validate(v Verse) error`. Required fields enforced: `id`, `tradition`, `lang`, `text`, `canonical_ref`, `source`, `checksum_sha256`. `inclusion_mode ∈ {bundled, api_only}`; `sensitivity ∈ {sacred_exact_quote}`.
- `internal/schema/verse_test.go` — happy path + every required-field omission + bad enum / format / range cases
- `Makefile` — `build`, `test`, `lint` (vet + staticcheck), plus `tidy`, `clean`
- `.github/workflows/ci.yml` — `go vet` + `staticcheck` + `go test ./...` on push and PR
- `.gitignore`

## Verification

Locally:
- `go build` succeeds; `./bin/scripture-mcp` prints `scripture-mcp v0.0.0`
- `go vet ./...` clean
- `staticcheck ./...` clean
- `go test ./...` passes (schema package tests)

## Acceptance criteria mapping

- [x] `go.mod` initialized at `github.com/MiaoDX/verse-driven`
- [x] Directory skeleton (`cmd/scripture-mcp/`, `internal/{packs,schema,resolver,mcp,cli,injector}`)
- [x] `cmd/scripture-mcp/main.go` builds and prints `scripture-mcp v0.0.0`
- [x] GitHub Actions: `go vet` + `staticcheck` + `go test ./...` on push and PR
- [x] `Makefile` with `build`, `test`, `lint` targets
- [x] `internal/schema/verse.schema.json` matches `plan.md` §6.1
- [x] `internal/schema/verse.go` defines the Go struct + `Validate(v Verse) error`
- [x] Required fields enforced
- [x] `inclusion_mode` and `sensitivity` enums enforced (extensible)
- [x] Schema tests cover happy path + each required-field omission + bad enum values

---
_Generated by [Claude Code](https://claude.ai/code/session_018z46gsakXiCVi9mEGTiJ5x)_