### PR TITLE
fix: #2 — feat(foundation): reference resolver with EN + ZH support

### DIFF
--- a/internal/resolver/bible.go
+++ b/internal/resolver/bible.go
@@ -1,0 +1,83 @@
+package resolver
+
+// bibleBook is one row of the Bible book alias table.
+type bibleBook struct {
+	canonical string   // canonical English name, e.g. "John", "1 John"
+	aliases   []string // lowercased aliases (English + Simplified Chinese)
+}
+
+// bibleBooks is the Bible alias table. All English aliases must be lowercase;
+// Chinese aliases are matched verbatim. Order is irrelevant — buildBibleIndex
+// sorts by alias length descending to ensure the longest match wins
+// (so "1 john" beats "john" on input "1 john 3:16").
+var bibleBooks = []bibleBook{
+	// Old Testament
+	{"Genesis", []string{"genesis", "gen", "gn", "ge", "创世记", "创"}},
+	{"Exodus", []string{"exodus", "exod", "exo", "ex", "出埃及记", "出"}},
+	{"Leviticus", []string{"leviticus", "lev", "lv", "利未记", "利"}},
+	{"Numbers", []string{"numbers", "num", "nm", "民数记", "民"}},
+	{"Deuteronomy", []string{"deuteronomy", "deut", "dt", "申命记", "申"}},
+	{"Joshua", []string{"joshua", "josh", "jos", "约书亚记", "书"}},
+	{"Judges", []string{"judges", "judg", "jdg", "士师记", "士"}},
+	{"Ruth", []string{"ruth", "rth", "ru", "路得记", "得"}},
+	{"1 Samuel", []string{"1 samuel", "1samuel", "1 sam", "1sam", "1 sa", "1sa", "i samuel", "撒母耳记上", "撒上"}},
+	{"2 Samuel", []string{"2 samuel", "2samuel", "2 sam", "2sam", "2 sa", "2sa", "ii samuel", "撒母耳记下", "撒下"}},
+	{"1 Kings", []string{"1 kings", "1kings", "1 kgs", "1kgs", "1 ki", "1ki", "i kings", "列王纪上", "王上"}},
+	{"2 Kings", []string{"2 kings", "2kings", "2 kgs", "2kgs", "2 ki", "2ki", "ii kings", "列王纪下", "王下"}},
+	{"1 Chronicles", []string{"1 chronicles", "1chronicles", "1 chron", "1chron", "1 chr", "1chr", "i chronicles", "历代志上", "代上"}},
+	{"2 Chronicles", []string{"2 chronicles", "2chronicles", "2 chron", "2chron", "2 chr", "2chr", "ii chronicles", "历代志下", "代下"}},
+	{"Ezra", []string{"ezra", "ezr", "以斯拉记", "拉"}},
+	{"Nehemiah", []string{"nehemiah", "neh", "ne", "尼希米记", "尼"}},
+	{"Esther", []string{"esther", "esth", "est", "以斯帖记", "斯"}},
+	{"Job", []string{"job", "jb", "约伯记", "伯"}},
+	{"Psalms", []string{"psalms", "psalm", "psa", "ps", "pss", "诗篇", "诗"}},
+	{"Proverbs", []string{"proverbs", "prov", "pr", "箴言", "箴"}},
+	{"Ecclesiastes", []string{"ecclesiastes", "eccl", "ec", "传道书", "传"}},
+	{"Song of Solomon", []string{"song of solomon", "song of songs", "song", "sos", "雅歌", "歌"}},
+	{"Isaiah", []string{"isaiah", "isa", "is", "以赛亚书", "赛"}},
+	{"Jeremiah", []string{"jeremiah", "jer", "je", "耶利米书", "耶"}},
+	{"Lamentations", []string{"lamentations", "lam", "la", "耶利米哀歌", "哀"}},
+	{"Ezekiel", []string{"ezekiel", "ezek", "ezk", "以西结书", "结"}},
+	{"Daniel", []string{"daniel", "dan", "da", "但以理书", "但"}},
+	{"Hosea", []string{"hosea", "hos", "ho", "何西阿书", "何"}},
+	{"Joel", []string{"joel", "joe", "jl", "约珥书", "珥"}},
+	{"Amos", []string{"amos", "amo", "am", "阿摩司书", "摩"}},
+	{"Obadiah", []string{"obadiah", "obad", "ob", "俄巴底亚书", "俄"}},
+	{"Jonah", []string{"jonah", "jon", "jnh", "约拿书", "拿"}},
+	{"Micah", []string{"micah", "mic", "mi", "弥迦书", "弥"}},
+	{"Nahum", []string{"nahum", "nah", "na", "那鸿书", "鸿"}},
+	{"Habakkuk", []string{"habakkuk", "hab", "hb", "哈巴谷书", "哈"}},
+	{"Zephaniah", []string{"zephaniah", "zeph", "zep", "西番雅书", "番"}},
+	{"Haggai", []string{"haggai", "hag", "hg", "哈该书", "该"}},
+	{"Zechariah", []string{"zechariah", "zech", "zec", "撒迦利亚书", "亚"}},
+	{"Malachi", []string{"malachi", "mal", "ml", "玛拉基书", "玛"}},
+
+	// New Testament
+	{"Matthew", []string{"matthew", "matt", "mt", "马太福音", "太"}},
+	{"Mark", []string{"mark", "mrk", "mk", "马可福音", "可"}},
+	{"Luke", []string{"luke", "luk", "lk", "路加福音", "路"}},
+	{"John", []string{"john", "joh", "jn", "约翰福音", "约"}},
+	{"Acts", []string{"acts", "act", "ac", "使徒行传", "徒"}},
+	{"Romans", []string{"romans", "rom", "ro", "罗马书", "罗"}},
+	{"1 Corinthians", []string{"1 corinthians", "1corinthians", "1 cor", "1cor", "1 co", "1co", "i corinthians", "哥林多前书", "林前"}},
+	{"2 Corinthians", []string{"2 corinthians", "2corinthians", "2 cor", "2cor", "2 co", "2co", "ii corinthians", "哥林多后书", "林后"}},
+	{"Galatians", []string{"galatians", "gal", "ga", "加拉太书", "加"}},
+	{"Ephesians", []string{"ephesians", "eph", "以弗所书", "弗"}},
+	{"Philippians", []string{"philippians", "phil", "php", "腓立比书", "腓"}},
+	{"Colossians", []string{"colossians", "col", "歌罗西书", "西"}},
+	{"1 Thessalonians", []string{"1 thessalonians", "1thessalonians", "1 thess", "1thess", "1 th", "1th", "i thessalonians", "帖撒罗尼迦前书", "帖前"}},
+	{"2 Thessalonians", []string{"2 thessalonians", "2thessalonians", "2 thess", "2thess", "2 th", "2th", "ii thessalonians", "帖撒罗尼迦后书", "帖后"}},
+	{"1 Timothy", []string{"1 timothy", "1timothy", "1 tim", "1tim", "1 ti", "1ti", "i timothy", "提摩太前书", "提前"}},
+	{"2 Timothy", []string{"2 timothy", "2timothy", "2 tim", "2tim", "2 ti", "2ti", "ii timothy", "提摩太后书", "提后"}},
+	{"Titus", []string{"titus", "tit", "ti", "提多书", "多"}},
+	{"Philemon", []string{"philemon", "phlm", "phm", "腓利门书", "门"}},
+	{"Hebrews", []string{"hebrews", "heb", "希伯来书", "来"}},
+	{"James", []string{"james", "jas", "jm", "雅各书", "雅"}},
+	{"1 Peter", []string{"1 peter", "1peter", "1 pet", "1pet", "1 pe", "1pe", "i peter", "彼得前书", "彼前"}},
+	{"2 Peter", []string{"2 peter", "2peter", "2 pet", "2pet", "2 pe", "2pe", "ii peter", "彼得后书", "彼后"}},
+	{"1 John", []string{"1 john", "1john", "1 jn", "1jn", "i john", "约翰一书", "约一"}},
+	{"2 John", []string{"2 john", "2john", "2 jn", "2jn", "ii john", "约翰二书", "约二"}},
+	{"3 John", []string{"3 john", "3john", "3 jn", "3jn", "iii john", "约翰三书", "约三"}},
+	{"Jude", []string{"jude", "jud", "jd", "犹大书", "犹"}},
+	{"Revelation", []string{"revelation", "rev", "re", "启示录", "启"}},
+}

--- a/internal/resolver/doc.go
+++ b/internal/resolver/doc.go
@@ -1,3 +1,0 @@
-// Package resolver parses free-form scripture references into canonical
-// (tradition, work, ref) tuples. Implementation lands in issue #2.
-package resolver

--- a/internal/resolver/numerals.go
+++ b/internal/resolver/numerals.go
@@ -1,0 +1,92 @@
+package resolver
+
+var cnDigit = map[rune]int{
+	'零': 0, '〇': 0,
+	'一': 1, '二': 2, '两': 2, '三': 3, '四': 4,
+	'五': 5, '六': 6, '七': 7, '八': 8, '九': 9,
+}
+
+// parseChineseNumeral parses Chinese numerals in the range 1..999.
+// Recognized forms include 一, 十, 十一, 二十, 二十三, 一百, 一百零一,
+// 一百二十三. Returns (n, true) on success, (0, false) on failure.
+func parseChineseNumeral(s string) (int, bool) {
+	rs := []rune(s)
+	if len(rs) == 0 {
+		return 0, false
+	}
+
+	n := 0
+	if i := indexRune(rs, '百'); i >= 0 {
+		if i != 1 {
+			return 0, false
+		}
+		d, ok := cnDigit[rs[0]]
+		if !ok || d == 0 {
+			return 0, false
+		}
+		n += d * 100
+		rs = rs[2:]
+		if len(rs) > 0 && (rs[0] == '零' || rs[0] == '〇') {
+			rs = rs[1:]
+			if len(rs) != 1 {
+				return 0, false
+			}
+			d, ok := cnDigit[rs[0]]
+			if !ok {
+				return 0, false
+			}
+			return n + d, true
+		}
+		if len(rs) == 0 {
+			return n, true
+		}
+	}
+
+	if i := indexRune(rs, '十'); i >= 0 {
+		tens := 1
+		switch i {
+		case 0:
+			// implicit one (e.g. 十, 十一)
+		case 1:
+			d, ok := cnDigit[rs[0]]
+			if !ok || d == 0 {
+				return 0, false
+			}
+			tens = d
+		default:
+			return 0, false
+		}
+		n += tens * 10
+		rest := rs[i+1:]
+		switch len(rest) {
+		case 0:
+			return n, true
+		case 1:
+			d, ok := cnDigit[rest[0]]
+			if !ok {
+				return 0, false
+			}
+			return n + d, true
+		default:
+			return 0, false
+		}
+	}
+
+	if len(rs) == 1 {
+		d, ok := cnDigit[rs[0]]
+		if !ok {
+			return 0, false
+		}
+		return n + d, true
+	}
+	return 0, false
+}
+
+func indexRune(rs []rune, r rune) int {
+	for i, c := range rs {
+		if c == r {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/resolver/quran.go
+++ b/internal/resolver/quran.go
@@ -1,0 +1,24 @@
+package resolver
+
+// quranSurah maps a surah's English/Arabic name to its number.
+type quranSurah struct {
+	number  int
+	aliases []string
+}
+
+// quranSurahs lists a representative subset of surahs by name. Lookup by
+// number (e.g. "Quran 2:255") is handled separately in the resolver.
+var quranSurahs = []quranSurah{
+	{1, []string{"al-fatihah", "al fatihah", "fatihah", "al-faatihah"}},
+	{2, []string{"al-baqarah", "al baqarah", "baqarah", "al-baqara"}},
+	{3, []string{"aal-imran", "ali imran", "al imran", "imran", "aal imran"}},
+	{4, []string{"an-nisa", "an nisa", "nisa", "al-nisa"}},
+	{5, []string{"al-maidah", "al maidah", "maidah"}},
+	{18, []string{"al-kahf", "al kahf", "kahf"}},
+	{36, []string{"yasin", "ya-sin", "ya sin", "yaseen"}},
+	{55, []string{"ar-rahman", "ar rahman", "rahman"}},
+	{67, []string{"al-mulk", "al mulk", "mulk"}},
+	{112, []string{"al-ikhlas", "al ikhlas", "ikhlas"}},
+	{113, []string{"al-falaq", "al falaq", "falaq"}},
+	{114, []string{"an-nas", "an nas", "nas"}},
+}

--- a/internal/resolver/reference.go
+++ b/internal/resolver/reference.go
@@ -1,0 +1,64 @@
+// Package resolver parses free-form scripture references into canonical
+// (tradition, work, ref) tuples. See plan.md §8.1 for the supported matrix.
+package resolver
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// Tradition identifiers.
+const (
+	TraditionBible = "bible"
+	TraditionDao   = "dao"
+	TraditionSutra = "sutra"
+	TraditionQuran = "quran"
+)
+
+// Work identifiers used in canonical references.
+const (
+	WorkKJV        = "KJV"
+	WorkDaodejing  = "daodejing"
+	WorkHeartSutra = "heart-sutra"
+	WorkQuran      = "quran"
+)
+
+// Reference is a parsed scripture reference.
+//
+// Book is empty for traditions without per-book structure
+// (Tao Te Ching, Heart Sutra, Quran-by-number).
+// Chapter == 0 means "whole work" (e.g. Heart Sutra has no chapters).
+// VerseStart == 0 means "no specific verse"; VerseEnd == 0 means "single
+// verse" (i.e. equivalent to VerseStart).
+type Reference struct {
+	Tradition  string
+	Work       string
+	Book       string
+	Chapter    int
+	VerseStart int
+	VerseEnd   int
+}
+
+// AmbiguousError is returned when input could plausibly resolve to more than
+// one reference (e.g. a bare "3:16" with no tradition keyword).
+type AmbiguousError struct {
+	Input      string
+	Candidates []Reference
+}
+
+func (e *AmbiguousError) Error() string {
+	parts := make([]string, 0, len(e.Candidates))
+	for _, c := range e.Candidates {
+		parts = append(parts, fmt.Sprintf("%s/%s %d:%d", c.Tradition, c.Work, c.Chapter, c.VerseStart))
+	}
+	return fmt.Sprintf("resolver: ambiguous reference %q; candidates: %s", e.Input, strings.Join(parts, ", "))
+}
+
+// Sentinel errors.
+var (
+	ErrEmpty         = errors.New("resolver: empty input")
+	ErrUnrecognized  = errors.New("resolver: unrecognized reference")
+	ErrInvalidNumber = errors.New("resolver: invalid chapter or verse")
+	ErrInvalidRange  = errors.New("resolver: verse_end must be >= verse_start")
+)

--- a/internal/resolver/resolve.go
+++ b/internal/resolver/resolve.go
@@ -1,0 +1,268 @@
+package resolver
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+)
+
+type bibleAlias struct {
+	alias     string
+	canonical string
+}
+
+type quranAlias struct {
+	alias  string
+	number int
+}
+
+var (
+	bibleAliasIndex []bibleAlias
+	quranAliasIndex []quranAlias
+
+	daoAliases       = []string{"tao te ching", "dao de jing", "daodejing", "道德经", "dao", "tao"}
+	sutraAliases     = []string{"般若波罗蜜多心经", "heart sutra", "sutra heart", "心经"}
+	quranTextAliases = []string{"古兰经", "quran", "qur'an", "koran"}
+	surahKeywords    = []string{"surah", "sura"}
+
+	reChapterVerse = regexp.MustCompile(`^\s*(\d+)\s*[:：]\s*(\d+)\s*(?:[\-–]\s*(\d+))?\s*$`)
+	reVerse        = regexp.MustCompile(`^\s*(\d+)\s*(?:[\-–]\s*(\d+))?\s*$`)
+)
+
+func init() {
+	for _, b := range bibleBooks {
+		for _, a := range b.aliases {
+			bibleAliasIndex = append(bibleAliasIndex, bibleAlias{alias: a, canonical: b.canonical})
+		}
+	}
+	sort.SliceStable(bibleAliasIndex, func(i, j int) bool {
+		return len(bibleAliasIndex[i].alias) > len(bibleAliasIndex[j].alias)
+	})
+	for _, q := range quranSurahs {
+		for _, a := range q.aliases {
+			quranAliasIndex = append(quranAliasIndex, quranAlias{alias: a, number: q.number})
+		}
+	}
+	sort.SliceStable(quranAliasIndex, func(i, j int) bool {
+		return len(quranAliasIndex[i].alias) > len(quranAliasIndex[j].alias)
+	})
+	sortByLenDesc(daoAliases)
+	sortByLenDesc(sutraAliases)
+	sortByLenDesc(quranTextAliases)
+	sortByLenDesc(surahKeywords)
+}
+
+func sortByLenDesc(s []string) {
+	sort.SliceStable(s, func(i, j int) bool { return len(s[i]) > len(s[j]) })
+}
+
+// Resolve parses a free-form scripture reference into a canonical Reference.
+// Errors wrap one of the package sentinels (ErrEmpty, ErrUnrecognized,
+// ErrInvalidNumber, ErrInvalidRange) or are *AmbiguousError when the input
+// cannot be uniquely classified.
+func Resolve(input string) (Reference, error) {
+	trimmed := strings.TrimSpace(input)
+	if trimmed == "" {
+		return Reference{}, ErrEmpty
+	}
+	norm := strings.ToLower(trimmed)
+
+	if rest, ok := matchAlias(norm, sutraAliases); ok {
+		if strings.TrimSpace(rest) != "" {
+			return Reference{}, fmt.Errorf("%w: heart sutra takes no chapter/verse", ErrUnrecognized)
+		}
+		return Reference{Tradition: TraditionSutra, Work: WorkHeartSutra}, nil
+	}
+
+	if rest, ok := matchAlias(norm, daoAliases); ok {
+		return parseDao(rest)
+	}
+
+	if rest, ok := matchAlias(norm, quranTextAliases); ok {
+		return parseQuranNumeric(rest)
+	}
+	if rest, ok := matchAlias(norm, surahKeywords); ok {
+		return parseQuranSurahByName(rest)
+	}
+
+	for _, e := range bibleAliasIndex {
+		if rest, ok := tryMatchPrefix(norm, e.alias); ok {
+			return parseBible(e.canonical, rest)
+		}
+	}
+
+	if c, v, _, ok := parseChapterVerse(norm); ok {
+		return Reference{}, &AmbiguousError{
+			Input: input,
+			Candidates: []Reference{
+				{Tradition: TraditionQuran, Work: WorkQuran, Chapter: c, VerseStart: v},
+				{Tradition: TraditionBible, Work: WorkKJV, Chapter: c, VerseStart: v},
+			},
+		}
+	}
+
+	return Reference{}, fmt.Errorf("%w: %q", ErrUnrecognized, input)
+}
+
+func parseDao(rest string) (Reference, error) {
+	rest = strings.TrimSpace(rest)
+	if r, ok := tryMatchPrefix(rest, "chapter"); ok {
+		rest = strings.TrimSpace(r)
+	}
+	rest = strings.TrimPrefix(rest, "第")
+	rest = strings.TrimSuffix(rest, "章")
+	rest = strings.TrimSpace(rest)
+	n, ok := parseNumber(rest)
+	if !ok || n < 1 {
+		return Reference{}, fmt.Errorf("%w: dao chapter %q", ErrInvalidNumber, rest)
+	}
+	return Reference{Tradition: TraditionDao, Work: WorkDaodejing, Chapter: n}, nil
+}
+
+func parseQuranNumeric(rest string) (Reference, error) {
+	rest = strings.TrimSpace(rest)
+	if rest == "" {
+		return Reference{}, fmt.Errorf("%w: quran reference missing surah/verse", ErrUnrecognized)
+	}
+	if c, v, ve, ok := parseChapterVerse(rest); ok {
+		if c < 1 || v < 1 {
+			return Reference{}, fmt.Errorf("%w: surah and verse must be >= 1", ErrInvalidNumber)
+		}
+		if ve != 0 && ve < v {
+			return Reference{}, ErrInvalidRange
+		}
+		return Reference{Tradition: TraditionQuran, Work: WorkQuran, Chapter: c, VerseStart: v, VerseEnd: ve}, nil
+	}
+	if n, ok := parseNumber(rest); ok && n >= 1 {
+		return Reference{Tradition: TraditionQuran, Work: WorkQuran, Chapter: n}, nil
+	}
+	return Reference{}, fmt.Errorf("%w: quran reference %q", ErrInvalidNumber, rest)
+}
+
+func parseQuranSurahByName(rest string) (Reference, error) {
+	rest = strings.TrimSpace(rest)
+	for _, e := range quranAliasIndex {
+		r, ok := tryMatchPrefix(rest, e.alias)
+		if !ok {
+			continue
+		}
+		r = strings.TrimSpace(r)
+		ref := Reference{Tradition: TraditionQuran, Work: WorkQuran, Chapter: e.number}
+		if r == "" {
+			return ref, nil
+		}
+		v, ve, ok := parseVerseOnly(r)
+		if !ok || v < 1 {
+			return Reference{}, fmt.Errorf("%w: invalid verse for surah: %q", ErrInvalidNumber, r)
+		}
+		if ve != 0 && ve < v {
+			return Reference{}, ErrInvalidRange
+		}
+		ref.VerseStart = v
+		ref.VerseEnd = ve
+		return ref, nil
+	}
+	return Reference{}, fmt.Errorf("%w: unknown surah %q", ErrUnrecognized, rest)
+}
+
+func parseBible(canonical, rest string) (Reference, error) {
+	rest = strings.TrimSpace(rest)
+	if rest == "" {
+		return Reference{}, fmt.Errorf("%w: %s reference missing chapter", ErrUnrecognized, canonical)
+	}
+	if c, v, ve, ok := parseChapterVerse(rest); ok {
+		if c < 1 || v < 1 {
+			return Reference{}, fmt.Errorf("%w: chapter and verse must be >= 1", ErrInvalidNumber)
+		}
+		if ve != 0 && ve < v {
+			return Reference{}, ErrInvalidRange
+		}
+		return Reference{
+			Tradition:  TraditionBible,
+			Work:       WorkKJV,
+			Book:       canonical,
+			Chapter:    c,
+			VerseStart: v,
+			VerseEnd:   ve,
+		}, nil
+	}
+	if n, ok := parseNumber(rest); ok && n >= 1 {
+		return Reference{
+			Tradition: TraditionBible,
+			Work:      WorkKJV,
+			Book:      canonical,
+			Chapter:   n,
+		}, nil
+	}
+	return Reference{}, fmt.Errorf("%w: invalid bible reference %q", ErrInvalidNumber, rest)
+}
+
+func matchAlias(input string, aliases []string) (string, bool) {
+	for _, a := range aliases {
+		if rest, ok := tryMatchPrefix(input, a); ok {
+			return rest, true
+		}
+	}
+	return "", false
+}
+
+// tryMatchPrefix returns input[len(alias):] if input starts with alias and
+// the next rune (if any) is not an ASCII letter. This prevents "jo" from
+// matching "joel" while still allowing CJK runs like "道德经第十一章" — for
+// CJK, longest-alias-first sorting handles the ambiguity instead.
+func tryMatchPrefix(input, alias string) (string, bool) {
+	if alias == "" || len(input) < len(alias) {
+		return "", false
+	}
+	if input[:len(alias)] != alias {
+		return "", false
+	}
+	rest := input[len(alias):]
+	if rest == "" {
+		return rest, true
+	}
+	r, _ := utf8.DecodeRuneInString(rest)
+	if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') {
+		return "", false
+	}
+	return rest, true
+}
+
+func parseChapterVerse(s string) (chapter, verse, verseEnd int, ok bool) {
+	m := reChapterVerse.FindStringSubmatch(s)
+	if m == nil {
+		return 0, 0, 0, false
+	}
+	chapter, _ = strconv.Atoi(m[1])
+	verse, _ = strconv.Atoi(m[2])
+	if m[3] != "" {
+		verseEnd, _ = strconv.Atoi(m[3])
+	}
+	return chapter, verse, verseEnd, true
+}
+
+func parseVerseOnly(s string) (verse, verseEnd int, ok bool) {
+	m := reVerse.FindStringSubmatch(s)
+	if m == nil {
+		return 0, 0, false
+	}
+	verse, _ = strconv.Atoi(m[1])
+	if m[2] != "" {
+		verseEnd, _ = strconv.Atoi(m[2])
+	}
+	return verse, verseEnd, true
+}
+
+func parseNumber(s string) (int, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, false
+	}
+	if n, err := strconv.Atoi(s); err == nil {
+		return n, true
+	}
+	return parseChineseNumeral(s)
+}

--- a/internal/resolver/resolve_test.go
+++ b/internal/resolver/resolve_test.go
@@ -1,0 +1,204 @@
+package resolver
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestResolve(t *testing.T) {
+	type want struct {
+		tradition  string
+		work       string
+		book       string
+		chapter    int
+		verseStart int
+		verseEnd   int
+	}
+
+	cases := []struct {
+		name  string
+		input string
+		want  want
+	}{
+		// Bible — English canonical
+		{"bible/john_full", "John 3:16", want{TraditionBible, WorkKJV, "John", 3, 16, 0}},
+		{"bible/john_lower", "john 3:16", want{TraditionBible, WorkKJV, "John", 3, 16, 0}},
+		{"bible/john_upper", "JOHN 3:16", want{TraditionBible, WorkKJV, "John", 3, 16, 0}},
+		{"bible/john_abbrev_jn", "Jn 3:16", want{TraditionBible, WorkKJV, "John", 3, 16, 0}},
+		{"bible/john_abbrev_joh", "Joh 3:16", want{TraditionBible, WorkKJV, "John", 3, 16, 0}},
+		{"bible/genesis", "Genesis 1:1", want{TraditionBible, WorkKJV, "Genesis", 1, 1, 0}},
+		{"bible/genesis_abbrev", "Gen 1:1", want{TraditionBible, WorkKJV, "Genesis", 1, 1, 0}},
+		{"bible/exodus", "Exodus 20:3", want{TraditionBible, WorkKJV, "Exodus", 20, 3, 0}},
+		{"bible/psalms", "Psalms 23:1", want{TraditionBible, WorkKJV, "Psalms", 23, 1, 0}},
+		{"bible/psalms_chapter_only", "Psalms 23", want{TraditionBible, WorkKJV, "Psalms", 23, 0, 0}},
+		{"bible/matthew_range", "Matthew 5:3-12", want{TraditionBible, WorkKJV, "Matthew", 5, 3, 12}},
+		{"bible/romans", "Romans 8:28", want{TraditionBible, WorkKJV, "Romans", 8, 28, 0}},
+		{"bible/revelation", "Revelation 22:21", want{TraditionBible, WorkKJV, "Revelation", 22, 21, 0}},
+		{"bible/jonah_vs_jn", "Jonah 1:1", want{TraditionBible, WorkKJV, "Jonah", 1, 1, 0}},
+		{"bible/joel_vs_john", "Joel 2:28", want{TraditionBible, WorkKJV, "Joel", 2, 28, 0}},
+
+		// Bible — numbered books, English variants
+		{"bible/1john_spaced", "1 John 3:16", want{TraditionBible, WorkKJV, "1 John", 3, 16, 0}},
+		{"bible/1john_unspaced", "1john 3:16", want{TraditionBible, WorkKJV, "1 John", 3, 16, 0}},
+		{"bible/1john_abbrev", "1 Jn 3:16", want{TraditionBible, WorkKJV, "1 John", 3, 16, 0}},
+		{"bible/1john_roman", "I John 3:16", want{TraditionBible, WorkKJV, "1 John", 3, 16, 0}},
+		{"bible/2john", "2 John 1:1", want{TraditionBible, WorkKJV, "2 John", 1, 1, 0}},
+		{"bible/3john", "3 John 1:4", want{TraditionBible, WorkKJV, "3 John", 1, 4, 0}},
+		{"bible/1corinthians", "1 Corinthians 13:4", want{TraditionBible, WorkKJV, "1 Corinthians", 13, 4, 0}},
+		{"bible/2samuel_abbrev", "2 Sam 7:12", want{TraditionBible, WorkKJV, "2 Samuel", 7, 12, 0}},
+
+		// Bible — Simplified Chinese
+		{"bible/john_zh", "约翰福音 3:16", want{TraditionBible, WorkKJV, "John", 3, 16, 0}},
+		{"bible/john_zh_no_space", "约翰福音3:16", want{TraditionBible, WorkKJV, "John", 3, 16, 0}},
+		{"bible/john_zh_fullwidth_colon", "约翰福音 3：16", want{TraditionBible, WorkKJV, "John", 3, 16, 0}},
+		{"bible/1john_zh", "约翰一书 3:16", want{TraditionBible, WorkKJV, "1 John", 3, 16, 0}},
+		{"bible/1john_zh_range", "约翰一书 3:16-17", want{TraditionBible, WorkKJV, "1 John", 3, 16, 17}},
+		{"bible/2john_zh", "约翰二书 1:1", want{TraditionBible, WorkKJV, "2 John", 1, 1, 0}},
+		{"bible/3john_zh", "约翰三书 1:4", want{TraditionBible, WorkKJV, "3 John", 1, 4, 0}},
+		{"bible/genesis_zh", "创世记 1:1", want{TraditionBible, WorkKJV, "Genesis", 1, 1, 0}},
+		{"bible/psalms_zh", "诗篇 23:1", want{TraditionBible, WorkKJV, "Psalms", 23, 1, 0}},
+		{"bible/matthew_zh", "马太福音 5:3", want{TraditionBible, WorkKJV, "Matthew", 5, 3, 0}},
+		{"bible/whitespace_padding", "   John 3:16   ", want{TraditionBible, WorkKJV, "John", 3, 16, 0}},
+
+		// Tao Te Ching
+		{"dao/zh_short", "道德经 11", want{TraditionDao, WorkDaodejing, "", 11, 0, 0}},
+		{"dao/zh_di_zhang", "道德经第十一章", want{TraditionDao, WorkDaodejing, "", 11, 0, 0}},
+		{"dao/zh_di_arabic", "道德经第11章", want{TraditionDao, WorkDaodejing, "", 11, 0, 0}},
+		{"dao/zh_chapter_one", "道德经第一章", want{TraditionDao, WorkDaodejing, "", 1, 0, 0}},
+		{"dao/zh_chapter_eighty_one", "道德经第八十一章", want{TraditionDao, WorkDaodejing, "", 81, 0, 0}},
+		{"dao/en_dao", "dao 11", want{TraditionDao, WorkDaodejing, "", 11, 0, 0}},
+		{"dao/en_dao_upper", "DAO 11", want{TraditionDao, WorkDaodejing, "", 11, 0, 0}},
+		{"dao/en_daodejing_chapter", "daodejing chapter 11", want{TraditionDao, WorkDaodejing, "", 11, 0, 0}},
+		{"dao/en_tao_te_ching", "Tao Te Ching 11", want{TraditionDao, WorkDaodejing, "", 11, 0, 0}},
+
+		// Heart Sutra
+		{"sutra/zh_short", "心经", want{TraditionSutra, WorkHeartSutra, "", 0, 0, 0}},
+		{"sutra/zh_full", "般若波罗蜜多心经", want{TraditionSutra, WorkHeartSutra, "", 0, 0, 0}},
+		{"sutra/en_heart_sutra", "Heart Sutra", want{TraditionSutra, WorkHeartSutra, "", 0, 0, 0}},
+		{"sutra/en_sutra_heart", "sutra heart", want{TraditionSutra, WorkHeartSutra, "", 0, 0, 0}},
+
+		// Quran
+		{"quran/numeric", "Quran 2:255", want{TraditionQuran, WorkQuran, "", 2, 255, 0}},
+		{"quran/numeric_lower", "quran 2:255", want{TraditionQuran, WorkQuran, "", 2, 255, 0}},
+		{"quran/zh", "古兰经 2:255", want{TraditionQuran, WorkQuran, "", 2, 255, 0}},
+		{"quran/zh_first_surah", "古兰经 1:1", want{TraditionQuran, WorkQuran, "", 1, 1, 0}},
+		{"quran/last_surah", "Quran 114:6", want{TraditionQuran, WorkQuran, "", 114, 6, 0}},
+		{"quran/range", "Quran 2:1-5", want{TraditionQuran, WorkQuran, "", 2, 1, 5}},
+		{"quran/surah_by_name", "Surah Al-Baqarah 255", want{TraditionQuran, WorkQuran, "", 2, 255, 0}},
+		{"quran/surah_by_name_lower", "surah al-fatihah 1", want{TraditionQuran, WorkQuran, "", 1, 1, 0}},
+		{"quran/surah_alt_spelling", "Surah Al Baqarah 255", want{TraditionQuran, WorkQuran, "", 2, 255, 0}},
+		{"quran/sura_keyword", "Sura Yasin 1", want{TraditionQuran, WorkQuran, "", 36, 1, 0}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Resolve(tc.input)
+			if err != nil {
+				t.Fatalf("Resolve(%q) returned error: %v", tc.input, err)
+			}
+			w := tc.want
+			if got.Tradition != w.tradition || got.Work != w.work || got.Book != w.book ||
+				got.Chapter != w.chapter || got.VerseStart != w.verseStart || got.VerseEnd != w.verseEnd {
+				t.Errorf("Resolve(%q) = %+v; want %+v", tc.input, got, w)
+			}
+		})
+	}
+}
+
+func TestResolveNegative(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		wantErr error
+	}{
+		{"empty", "", ErrEmpty},
+		{"whitespace_only", "   ", ErrEmpty},
+		{"unrecognized_word", "asdfghjkl", ErrUnrecognized},
+		{"unrecognized_phrase", "the quick brown fox", ErrUnrecognized},
+		{"bible_zero_chapter", "John 0:1", ErrInvalidNumber},
+		{"bible_zero_verse", "John 1:0", ErrInvalidNumber},
+		{"bible_negative_garbage", "John 3:abc", ErrInvalidNumber},
+		{"bible_book_only", "John", ErrUnrecognized},
+		{"bible_inverted_range", "John 3:16-15", ErrInvalidRange},
+		{"dao_zero", "道德经 0", ErrInvalidNumber},
+		{"dao_garbage", "道德经 abc", ErrInvalidNumber},
+		{"sutra_with_chapter", "心经 1:1", ErrUnrecognized},
+		{"quran_no_ref", "Quran", ErrUnrecognized},
+		{"quran_garbage", "Quran abc", ErrInvalidNumber},
+		{"quran_zero_chapter", "Quran 0:1", ErrInvalidNumber},
+		{"quran_unknown_surah", "Surah Foobar 1", ErrUnrecognized},
+		{"quran_inverted_range", "Quran 2:5-1", ErrInvalidRange},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Resolve(tc.input)
+			if err == nil {
+				t.Fatalf("Resolve(%q) expected error %v, got nil", tc.input, tc.wantErr)
+			}
+			if !errors.Is(err, tc.wantErr) {
+				t.Errorf("Resolve(%q) error = %v; want errors.Is(_, %v)", tc.input, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestResolveAmbiguous(t *testing.T) {
+	cases := []string{"3:16", "1:1", "2:255"}
+	for _, in := range cases {
+		t.Run(in, func(t *testing.T) {
+			_, err := Resolve(in)
+			if err == nil {
+				t.Fatalf("Resolve(%q) expected AmbiguousError, got nil", in)
+			}
+			var amb *AmbiguousError
+			if !errors.As(err, &amb) {
+				t.Fatalf("Resolve(%q) error = %v; want *AmbiguousError", in, err)
+			}
+			if amb.Input != in {
+				t.Errorf("AmbiguousError.Input = %q; want %q", amb.Input, in)
+			}
+			if len(amb.Candidates) == 0 {
+				t.Errorf("AmbiguousError.Candidates is empty")
+			}
+		})
+	}
+}
+
+func TestParseChineseNumeral(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int
+		ok   bool
+	}{
+		{"一", 1, true},
+		{"二", 2, true},
+		{"九", 9, true},
+		{"十", 10, true},
+		{"十一", 11, true},
+		{"十九", 19, true},
+		{"二十", 20, true},
+		{"二十三", 23, true},
+		{"八十一", 81, true},
+		{"九十九", 99, true},
+		{"一百", 100, true},
+		{"一百零一", 101, true},
+		{"一百二十三", 123, true},
+		{"", 0, false},
+		{"零", 0, true}, // 零 alone parses as 0; callers reject n<1
+		{"百", 0, false},
+		{"abc", 0, false},
+		{"十十", 0, false},
+		{"二三", 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			got, ok := parseChineseNumeral(tc.in)
+			if ok != tc.ok {
+				t.Fatalf("parseChineseNumeral(%q) ok = %v; want %v", tc.in, ok, tc.ok)
+			}
+			if ok && got != tc.want {
+				t.Errorf("parseChineseNumeral(%q) = %d; want %d", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #2.

Parses a free-form scripture reference into a canonical `Reference{Tradition, Work, Book?, Chapter, VerseStart, VerseEnd?}` per `plan.md` §8.1.

## What's in this PR

- `internal/resolver/reference.go` — `Reference` struct, tradition/work constants, `*AmbiguousError`, sentinel errors (`ErrEmpty`, `ErrUnrecognized`, `ErrInvalidNumber`, `ErrInvalidRange`)
- `internal/resolver/resolve.go` — `Resolve(input string) (Reference, error)` entry point + per-tradition dispatch + a `tryMatchPrefix` helper that uses an ASCII-letter boundary so `"jo"` won't beat `"joel"`
- `internal/resolver/bible.go` — full 66-book alias table (English canonical + common abbreviations + Simplified Chinese)
- `internal/resolver/quran.go` — ~12 popular surahs by name
- `internal/resolver/numerals.go` — Chinese numeral parser for 1..999 (`一`, `十`, `十一`, `二十`, `八十一`, `一百零一`, `一百二十三` ...)
- `internal/resolver/resolve_test.go` — 50+ positive, 17 negative, 3 ambiguous, 19 numeral cases

## Acceptance criteria mapping

- [x] Parses Bible: `John 3:16`, `Jn 3:16`, `1 John 3:16`, `约翰福音 3:16`, `约翰一书 3:16`
- [x] Parses Tao Te Ching: `dao 11`, `daodejing chapter 11`, `道德经 11`, `道德经第十一章`
- [x] Parses Heart Sutra: `sutra heart`, `心经`, `般若波罗蜜多心经`
- [x] Parses Quran: `Quran 2:255`, `2:255`, `Surah Al-Baqarah 255`
- [x] Returns canonical `Reference{Tradition, Work, Book?, Chapter, VerseStart, VerseEnd?}`
- [x] Ambiguous bare `3:16` returns `*AmbiguousError` with candidates (Quran + Bible-shape)
- [x] Table-driven tests with ≥ 50 inputs across all 4 traditions, both languages, plus negatives

## Design notes

- Per-tradition alias tables sorted by byte length descending so longer matches win — `"1 john"` beats `"john"`, `"约翰福音"` beats `"约"`.
- The ASCII-letter boundary in `tryMatchPrefix` is intentionally narrow: rejecting any letter would break CJK chains like `"道德经第十一章"` (CJK ideographs are letters by Unicode category). Longest-first sorting handles CJK ambiguity instead.
- Errors wrap the package sentinels with `fmt.Errorf("%w: ...", ...)` so callers can use `errors.Is`. `*AmbiguousError` is returned as a typed error so callers can use `errors.As`.

## Verification

- `go vet ./...` clean
- `staticcheck ./...` clean
- `go test ./...` — `internal/resolver` and `internal/schema` both PASS

---
_Generated by [Claude Code](https://claude.ai/code/session_017oFxiyRdiLLc32qfADHFav)_