### PR TITLE
fix: #4 — feat(core): stdio MCP server + CLI subcommands

### DIFF
--- a/cmd/scripture-mcp/main.go
+++ b/cmd/scripture-mcp/main.go
@@ -1,78 +1,76 @@
-// scripture-mcp is the verse-driven binary. The full CLI surface
-// (serve / lookup / lookup-from-prompt / recap / init) is implemented
-// in issue #4. This entrypoint exposes just enough now to demonstrate
-// that the embedded packs from issue #3 are reachable from main.
+// scripture-mcp is the verse-driven binary. One executable, five
+// subcommands:
 //
-// Usage:
+//	scripture-mcp serve                 — stdio MCP server for Claude/Codex
+//	scripture-mcp lookup "<ref>"        — print a verse (json|text)
+//	scripture-mcp lookup-from-prompt    — hook integration: stdin → JSON
+//	scripture-mcp recap [flags]         — Mode B terminal-only recap
+//	scripture-mcp init --target=...     — splice config snippets into agents
 //
-//	scripture-mcp                       # prints version and pack summary
-//	scripture-mcp --packs               # prints loaded pack metadata
-//	scripture-mcp --lookup-id <id>      # prints the canonical reference and
-//	                                    # SHA-256 of one verse (text omitted
-//	                                    # to keep terminal output filter-safe)
+// With no subcommand, prints version + pack summary.
 package main
 
 import (
-	"flag"
+	"context"
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
 
+	"github.com/MiaoDX/verse-driven/internal/cli"
+	"github.com/MiaoDX/verse-driven/internal/mcp"
 	"github.com/MiaoDX/verse-driven/internal/packs"
 )
 
-const Version = "v0.0.0"
+const Version = "v0.1.0"
 
 func main() {
-	listPacks := flag.Bool("packs", false, "list loaded packs and exit")
-	lookupID := flag.String("lookup-id", "", "look up a verse by id and print metadata only")
-	flag.Parse()
-
-	switch {
-	case *listPacks:
-		printPacks()
-	case *lookupID != "":
-		if err := printLookup(*lookupID); err != nil {
-			fmt.Fprintln(os.Stderr, "error:", err)
-			os.Exit(1)
-		}
-	default:
+	if len(os.Args) < 2 {
 		fmt.Printf("scripture-mcp %s\n", Version)
 		fmt.Printf("packs loaded: %d  total verses: %d\n",
 			len(packs.All().Names()), packs.All().TotalVerses())
+		fmt.Println("usage: scripture-mcp {serve|lookup|lookup-from-prompt|recap|init} [flags]")
+		return
+	}
+	streams := cli.Streams{In: os.Stdin, Out: os.Stdout, Err: os.Stderr}
+	sub := os.Args[1]
+	args := os.Args[2:]
+	switch sub {
+	case "-h", "--help", "help":
+		printHelp()
+		return
+	case "-v", "--version", "version":
+		fmt.Println(Version)
+		return
+	case "serve":
+		os.Exit(runServe(args))
+	default:
+		os.Exit(cli.Run(sub, args, streams))
 	}
 }
 
-func printPacks() {
-	r := packs.All()
-	for _, name := range r.Names() {
-		p := r.Pack(name)
-		mode := p.Meta.InclusionMode
-		if mode == "" {
-			mode = "(unset)"
-		}
-		fmt.Printf("%-14s tradition=%-6s work=%-12s lang=%-6s verses=%-6d mode=%s\n",
-			name, p.Meta.Tradition, p.Meta.Work, p.Meta.Lang, len(p.Verses()), mode)
-	}
-}
-
-func printLookup(id string) error {
-	v, ok := packs.All().Lookup(id)
-	if !ok {
-		return fmt.Errorf("verse not found: %s", id)
-	}
-	// Deliberately print only structural fields — never the verse text.
-	// Callers who need the body should go through the MCP `lookup` tool
-	// (issue #4), which has explicit user-confirm gating.
-	fmt.Printf("id:        %s\n", v.ID)
-	fmt.Printf("tradition: %s/%s\n", v.Tradition, v.Work)
-	fmt.Printf("ref:       %s %d:%d", v.CanonicalRef.Book, v.CanonicalRef.Chapter, v.CanonicalRef.VerseStart)
-	if v.CanonicalRef.VerseEnd != 0 {
-		fmt.Printf("-%d", v.CanonicalRef.VerseEnd)
-	}
+func printHelp() {
+	fmt.Println("scripture-mcp", Version)
 	fmt.Println()
-	fmt.Printf("lang:      %s\n", v.Lang)
-	fmt.Printf("checksum:  %s\n", v.ChecksumSHA256)
-	fmt.Printf("text_len:  %d bytes\n", len(v.Text))
-	fmt.Printf("source:    %s — %s\n", v.Source.Provider, v.Source.License)
-	return nil
+	fmt.Println("Usage:")
+	fmt.Println("  scripture-mcp serve                              start stdio MCP server")
+	fmt.Println("  scripture-mcp lookup \"<ref>\" [--format=json|text] resolve and print a verse")
+	fmt.Println("  scripture-mcp lookup-from-prompt                 hook integration (stdin → JSON)")
+	fmt.Println("  scripture-mcp recap [--tradition=<t>] [--terminal] [--first-letter] [--seed=<n>]")
+	fmt.Println("  scripture-mcp init --target={claude-code|codex} [--recap=on|off] [--uninstall]")
+}
+
+func runServe(args []string) int {
+	if len(args) > 0 {
+		fmt.Fprintln(os.Stderr, "error: serve takes no arguments")
+		return 2
+	}
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	srv := mcp.New(packs.All())
+	if err := srv.Serve(ctx, os.Stdin, os.Stdout); err != nil && err != context.Canceled {
+		fmt.Fprintln(os.Stderr, "scripture-mcp serve:", err)
+		return 1
+	}
+	return 0
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1,0 +1,80 @@
+// Package cli implements the scripture-mcp subcommand surface:
+// lookup, lookup-from-prompt, recap, and init.
+//
+// Subcommands are dispatched from cmd/scripture-mcp/main.go via Run.
+// Tests for each subcommand live alongside the file that implements it.
+package cli
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/MiaoDX/verse-driven/internal/packs"
+	"github.com/MiaoDX/verse-driven/internal/resolver"
+	"github.com/MiaoDX/verse-driven/internal/schema"
+)
+
+// Streams bundles the stdio handles a subcommand reads/writes. Tests inject
+// in-memory buffers; main wires os.Stdin/Stdout/Stderr.
+type Streams struct {
+	In     io.Reader
+	Out    io.Writer
+	Err    io.Writer
+	HomeFn func() (string, error) // override for init's config-file location
+}
+
+// Run dispatches to the named subcommand. args excludes the subcommand
+// itself (i.e. caller passes os.Args[2:]).
+func Run(name string, args []string, s Streams) int {
+	switch name {
+	case "lookup":
+		return runLookup(args, s)
+	case "lookup-from-prompt":
+		return runLookupFromPrompt(args, s)
+	case "recap":
+		return runRecap(args, s)
+	case "init":
+		return runInit(args, s)
+	default:
+		fmt.Fprintf(s.Err, "unknown subcommand: %q\n", name)
+		fmt.Fprintln(s.Err, "usage: scripture-mcp {serve|lookup|lookup-from-prompt|recap|init} [flags]")
+		return 2
+	}
+}
+
+// reorderFlagsFirst moves all `--flag` / `-flag` (with optional `=value`)
+// args ahead of positional args, so that `lookup "John 3:16" --format=json`
+// parses identically to `lookup --format=json "John 3:16"`. The standard
+// flag package stops at the first positional arg by design; the issue
+// spec mixes flag and positional order, so we normalize before parsing.
+//
+// We deliberately do not handle `--flag value` (two-token form): the
+// CLI uses `=value` exclusively to keep the rule trivially correct.
+func reorderFlagsFirst(args []string) []string {
+	var flags, positional []string
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		if a == "--" {
+			// Standard convention: everything after `--` is positional.
+			positional = append(positional, args[i+1:]...)
+			break
+		}
+		if len(a) >= 2 && a[0] == '-' {
+			flags = append(flags, a)
+			continue
+		}
+		positional = append(positional, a)
+	}
+	return append(flags, positional...)
+}
+
+// resolveAndLookup parses a free-form reference and resolves it to a
+// bundled verse. Returns packs.ErrNotBundled when the reference resolved
+// to a tradition shipped api-only in this build (heart-sutra, quran).
+func resolveAndLookup(ref string) (schema.Verse, error) {
+	r, err := resolver.Resolve(ref)
+	if err != nil {
+		return schema.Verse{}, err
+	}
+	return packs.LookupReference(r)
+}

--- a/internal/cli/doc.go
+++ b/internal/cli/doc.go
@@ -1,2 +1,0 @@
-// Package cli implements the lookup / recap / init subcommands. Lands in issue #4.
-package cli

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -1,0 +1,244 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// runInit implements `scripture-mcp init --target={claude-code,codex}
+// [--recap=on|off] [--uninstall]`.
+//
+// Idempotent: rerunning with the same flags is a no-op once the snippet
+// is installed. We never overwrite the user's config — we splice in (or
+// strip out) a marker-fenced block.
+func runInit(args []string, s Streams) int {
+	fs := flag.NewFlagSet("init", flag.ContinueOnError)
+	fs.SetOutput(s.Err)
+	target := fs.String("target", "", "agent target: claude-code|codex")
+	recap := fs.String("recap", "on", "enable Mode B recap: on|off")
+	uninstall := fs.Bool("uninstall", false, "remove the snippet instead of installing it")
+	dryRun := fs.Bool("dry-run", false, "print what would change without writing")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if *target == "" {
+		fmt.Fprintln(s.Err, "error: --target is required (claude-code|codex)")
+		return 2
+	}
+	switch *recap {
+	case "on", "off":
+	default:
+		fmt.Fprintln(s.Err, "error: --recap must be on|off")
+		return 2
+	}
+	home, err := homeDir(s)
+	if err != nil {
+		fmt.Fprintln(s.Err, "error:", err)
+		return 1
+	}
+
+	switch *target {
+	case "claude-code":
+		path := filepath.Join(home, ".claude", "settings.json")
+		return manageSnippet(path, "// >>> verse-driven", "// <<< verse-driven",
+			renderClaudeSnippet(*recap == "on"), *uninstall, *dryRun, s)
+	case "codex":
+		path := filepath.Join(home, ".codex", "config.toml")
+		return manageSnippet(path, "# >>> verse-driven", "# <<< verse-driven",
+			renderCodexSnippet(*recap == "on"), *uninstall, *dryRun, s)
+	default:
+		fmt.Fprintf(s.Err, "error: unknown target %q (want claude-code|codex)\n", *target)
+		return 2
+	}
+}
+
+func homeDir(s Streams) (string, error) {
+	if s.HomeFn != nil {
+		return s.HomeFn()
+	}
+	return os.UserHomeDir()
+}
+
+// manageSnippet inserts (or removes) snippet between begin/end marker
+// lines in the file at path. The snippet itself must already include the
+// markers; we identify the existing block by scanning for them and we
+// idempotently replace it.
+//
+// File creation: when installing into a missing file, we create the
+// parent directory and write a file containing only the snippet. When
+// uninstalling from a missing file, we treat it as a no-op.
+func manageSnippet(path, beginMarker, endMarker, snippet string, uninstall, dryRun bool, s Streams) int {
+	existing, exists, err := readIfExists(path)
+	if err != nil {
+		fmt.Fprintln(s.Err, "error:", err)
+		return 1
+	}
+	updated, changed := spliceSnippet(existing, exists, beginMarker, endMarker, snippet, uninstall)
+	if !changed {
+		fmt.Fprintf(s.Out, "verse-driven: %s already up to date\n", path)
+		return 0
+	}
+	if dryRun {
+		fmt.Fprintf(s.Out, "verse-driven: would write %s\n", path)
+		fmt.Fprintln(s.Out, "---")
+		fmt.Fprint(s.Out, updated)
+		fmt.Fprintln(s.Out, "---")
+		return 0
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		fmt.Fprintln(s.Err, "error: mkdir:", err)
+		return 1
+	}
+	if err := os.WriteFile(path, []byte(updated), 0o644); err != nil {
+		fmt.Fprintln(s.Err, "error: write:", err)
+		return 1
+	}
+	if uninstall {
+		fmt.Fprintf(s.Out, "verse-driven: removed snippet from %s\n", path)
+	} else {
+		fmt.Fprintf(s.Out, "verse-driven: installed snippet into %s\n", path)
+	}
+	return 0
+}
+
+func readIfExists(path string) (string, bool, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", false, nil
+		}
+		return "", false, fmt.Errorf("read %s: %w", path, err)
+	}
+	return string(b), true, nil
+}
+
+// spliceSnippet returns the updated file contents and whether anything
+// would change. snippet is wrapped in a marker-fenced block; if the file
+// already contains markers, the block between them is replaced. On
+// install into a missing file, a fresh file with only the snippet block
+// is produced. On uninstall, the block is stripped (and trailing blank
+// lines collapsed).
+func spliceSnippet(existing string, exists bool, beginMarker, endMarker, snippet string, uninstall bool) (string, bool) {
+	block := beginMarker + "\n" + snippet
+	if !strings.HasSuffix(block, "\n") {
+		block += "\n"
+	}
+	block += endMarker + "\n"
+
+	beginIdx := strings.Index(existing, beginMarker)
+	endIdx := strings.Index(existing, endMarker)
+	hasBlock := beginIdx >= 0 && endIdx > beginIdx
+
+	if uninstall {
+		if !exists || !hasBlock {
+			return existing, false
+		}
+		afterEnd := endIdx + len(endMarker)
+		// Eat the newline immediately following endMarker (and only one).
+		if afterEnd < len(existing) && existing[afterEnd] == '\n' {
+			afterEnd++
+		}
+		// Eat one preceding newline before beginIdx if present so we don't
+		// leave a blank line where the block was.
+		startCut := beginIdx
+		if startCut > 0 && existing[startCut-1] == '\n' {
+			startCut--
+		}
+		out := existing[:startCut] + existing[afterEnd:]
+		return out, out != existing
+	}
+
+	if !exists {
+		return block, true
+	}
+	if hasBlock {
+		afterEnd := endIdx + len(endMarker)
+		if afterEnd < len(existing) && existing[afterEnd] == '\n' {
+			afterEnd++
+		}
+		out := existing[:beginIdx] + block + existing[afterEnd:]
+		return out, out != existing
+	}
+	prefix := existing
+	if !strings.HasSuffix(prefix, "\n") {
+		prefix += "\n"
+	}
+	if prefix != "" && !strings.HasSuffix(prefix, "\n\n") {
+		prefix += "\n"
+	}
+	out := prefix + block
+	return out, out != existing
+}
+
+// renderClaudeSnippet returns the JSON-with-comments snippet inserted
+// into ~/.claude/settings.json. We deliberately use shell-style comments
+// as fence markers (rather than valid JSON) because settings.json
+// itself is parsed as JSON5/JSON-with-comments by Claude Code.
+//
+// The snippet matches plan.md §5.1.
+func renderClaudeSnippet(recapOn bool) string {
+	stopBlock := ""
+	if recapOn {
+		stopBlock = `,
+    "Stop": [
+      {
+        "hooks": [
+          { "type": "command", "command": "scripture-mcp recap --terminal" }
+        ]
+      }
+    ]`
+	}
+	return `// Generated by scripture-mcp init --target=claude-code.
+// This block is managed automatically; edit between the markers will be
+// overwritten on the next ` + "`" + `scripture-mcp init` + "`" + `.
+{
+  "mcpServers": {
+    "scripture": {
+      "command": "scripture-mcp",
+      "args": ["serve"]
+    }
+  },
+  "hooks": {
+    "UserPromptExpansion": [
+      {
+        "matcher": "^(bible|sutra|dao|quran)$",
+        "hooks": [
+          { "type": "command", "command": "scripture-mcp lookup-from-prompt" }
+        ]
+      }
+    ]` + stopBlock + `
+  }
+}
+`
+}
+
+// renderCodexSnippet returns the TOML snippet for ~/.codex/config.toml,
+// matching plan.md §5.2. Codex has no Stop-equivalent hook, so the recap
+// is wired via the `cdx` shell wrapper from issue #6 — recap=on here is
+// informational; the actual wrapper install path isn't part of init's
+// JSON/TOML splice.
+func renderCodexSnippet(recapOn bool) string {
+	recapNote := "# recap: launch via the cdx shell wrapper (see adapters/codex/wrapper/cdx).\n"
+	if !recapOn {
+		recapNote = "# recap: disabled (cdx wrapper omitted).\n"
+	}
+	return `# Generated by scripture-mcp init --target=codex.
+# This block is managed automatically; edits between the markers will be
+# overwritten on the next ` + "`" + `scripture-mcp init` + "`" + `.
+[mcp_servers.scripture]
+command = "scripture-mcp"
+args = ["serve"]
+
+[features]
+codex_hooks = true
+
+[[hooks.UserPromptSubmit]]
+[[hooks.UserPromptSubmit.hooks]]
+type = "command"
+command = "scripture-mcp lookup-from-prompt"
+timeout = 15
+` + recapNote
+}

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -1,0 +1,168 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func tempHome(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	return dir
+}
+
+func runInitWithHome(t *testing.T, home string, args ...string) (string, string, int) {
+	t.Helper()
+	var out, errBuf bytes.Buffer
+	code := runInit(args, Streams{
+		Out: &out, Err: &errBuf,
+		HomeFn: func() (string, error) { return home, nil },
+	})
+	return out.String(), errBuf.String(), code
+}
+
+func TestInitClaudeCreatesFile(t *testing.T) {
+	home := tempHome(t)
+	_, errOut, code := runInitWithHome(t, home, "--target=claude-code")
+	if code != 0 {
+		t.Fatalf("exit %d: %s", code, errOut)
+	}
+	body, err := os.ReadFile(filepath.Join(home, ".claude", "settings.json"))
+	if err != nil {
+		t.Fatalf("settings.json not created: %v", err)
+	}
+	s := string(body)
+	for _, want := range []string{
+		"// >>> verse-driven",
+		"// <<< verse-driven",
+		"\"command\": \"scripture-mcp\"",
+		"\"args\": [\"serve\"]",
+		"UserPromptExpansion",
+		"scripture-mcp lookup-from-prompt",
+		"scripture-mcp recap --terminal",
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("settings.json missing %q\n--- file ---\n%s", want, s)
+		}
+	}
+}
+
+func TestInitClaudeRecapOff(t *testing.T) {
+	home := tempHome(t)
+	if _, _, code := runInitWithHome(t, home, "--target=claude-code", "--recap=off"); code != 0 {
+		t.Fatalf("exit %d", code)
+	}
+	body, _ := os.ReadFile(filepath.Join(home, ".claude", "settings.json"))
+	if strings.Contains(string(body), "recap --terminal") {
+		t.Errorf("recap=off should omit Stop hook:\n%s", body)
+	}
+}
+
+func TestInitIdempotent(t *testing.T) {
+	home := tempHome(t)
+	if _, _, code := runInitWithHome(t, home, "--target=claude-code"); code != 0 {
+		t.Fatalf("first run exit %d", code)
+	}
+	first, _ := os.ReadFile(filepath.Join(home, ".claude", "settings.json"))
+	stdout, _, code := runInitWithHome(t, home, "--target=claude-code")
+	if code != 0 {
+		t.Fatalf("second run exit %d", code)
+	}
+	if !strings.Contains(stdout, "already up to date") {
+		t.Errorf("second run should report no-op: %q", stdout)
+	}
+	second, _ := os.ReadFile(filepath.Join(home, ".claude", "settings.json"))
+	if string(first) != string(second) {
+		t.Errorf("idempotent run modified file:\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+}
+
+func TestInitPreservesUserContent(t *testing.T) {
+	home := tempHome(t)
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	user := "// my custom settings\n{\"theme\":\"dark\"}\n"
+	path := filepath.Join(home, ".claude", "settings.json")
+	if err := os.WriteFile(path, []byte(user), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, code := runInitWithHome(t, home, "--target=claude-code"); code != 0 {
+		t.Fatalf("exit %d", code)
+	}
+	body, _ := os.ReadFile(path)
+	s := string(body)
+	if !strings.Contains(s, "my custom settings") {
+		t.Errorf("user content was clobbered:\n%s", s)
+	}
+	if !strings.Contains(s, "// >>> verse-driven") {
+		t.Errorf("snippet not appended:\n%s", s)
+	}
+}
+
+func TestInitUninstall(t *testing.T) {
+	home := tempHome(t)
+	if _, _, code := runInitWithHome(t, home, "--target=claude-code"); code != 0 {
+		t.Fatalf("install exit %d", code)
+	}
+	if _, _, code := runInitWithHome(t, home, "--target=claude-code", "--uninstall"); code != 0 {
+		t.Fatalf("uninstall exit %d", code)
+	}
+	body, _ := os.ReadFile(filepath.Join(home, ".claude", "settings.json"))
+	if strings.Contains(string(body), "verse-driven") {
+		t.Errorf("snippet not removed:\n%s", body)
+	}
+}
+
+func TestInitCodexCreatesToml(t *testing.T) {
+	home := tempHome(t)
+	if _, _, code := runInitWithHome(t, home, "--target=codex"); code != 0 {
+		t.Fatalf("exit %d", code)
+	}
+	body, err := os.ReadFile(filepath.Join(home, ".codex", "config.toml"))
+	if err != nil {
+		t.Fatalf("config.toml not created: %v", err)
+	}
+	s := string(body)
+	for _, want := range []string{
+		"# >>> verse-driven",
+		"# <<< verse-driven",
+		"[mcp_servers.scripture]",
+		"command = \"scripture-mcp\"",
+		"[features]",
+		"codex_hooks = true",
+		"[[hooks.UserPromptSubmit]]",
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("config.toml missing %q\n--- file ---\n%s", want, s)
+		}
+	}
+}
+
+func TestInitMissingTarget(t *testing.T) {
+	home := tempHome(t)
+	_, errOut, code := runInitWithHome(t, home)
+	if code != 2 {
+		t.Errorf("exit %d, want 2", code)
+	}
+	if !strings.Contains(errOut, "--target") {
+		t.Errorf("stderr should mention --target: %s", errOut)
+	}
+}
+
+func TestInitDryRun(t *testing.T) {
+	home := tempHome(t)
+	stdout, _, code := runInitWithHome(t, home, "--target=claude-code", "--dry-run")
+	if code != 0 {
+		t.Fatalf("exit %d", code)
+	}
+	if !strings.Contains(stdout, "would write") {
+		t.Errorf("dry-run should report 'would write': %s", stdout)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".claude", "settings.json")); err == nil {
+		t.Error("dry-run wrote a file")
+	}
+}

--- a/internal/cli/lookup.go
+++ b/internal/cli/lookup.go
@@ -1,0 +1,243 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+
+	"github.com/MiaoDX/verse-driven/internal/injector"
+	"github.com/MiaoDX/verse-driven/internal/resolver"
+	"github.com/MiaoDX/verse-driven/internal/schema"
+)
+
+// runLookup implements `scripture-mcp lookup "<ref>" [--format=json|text]`.
+//
+// On success: prints the resolved verse (JSON by default, terminal-pretty
+// with --format=text) and exits 0. On failure: prints "error: ..." to
+// stderr and exits 1; ambiguous input exits with code 3.
+func runLookup(args []string, s Streams) int {
+	fs := flag.NewFlagSet("lookup", flag.ContinueOnError)
+	fs.SetOutput(s.Err)
+	format := fs.String("format", "json", "output format: json|text")
+	if err := fs.Parse(reorderFlagsFirst(args)); err != nil {
+		return 2
+	}
+	rest := fs.Args()
+	if len(rest) == 0 {
+		fmt.Fprintln(s.Err, "error: usage: scripture-mcp lookup \"<reference>\" [--format=json|text]")
+		return 2
+	}
+	ref := strings.Join(rest, " ")
+	v, err := resolveAndLookup(ref)
+	if err != nil {
+		var amb *resolver.AmbiguousError
+		if errors.As(err, &amb) {
+			fmt.Fprintf(s.Err, "error: ambiguous reference %q; specify a tradition\n", amb.Input)
+			for _, c := range amb.Candidates {
+				fmt.Fprintf(s.Err, "  - %s/%s %d:%d\n", c.Tradition, c.Work, c.Chapter, c.VerseStart)
+			}
+			return 3
+		}
+		fmt.Fprintln(s.Err, "error:", err)
+		return 1
+	}
+	switch *format {
+	case "json":
+		return writeJSON(s.Out, v)
+	case "text":
+		return writeTerminal(s.Out, v)
+	default:
+		fmt.Fprintf(s.Err, "error: unknown format %q (want json|text)\n", *format)
+		return 2
+	}
+}
+
+func writeJSON(w io.Writer, v schema.Verse) int {
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(v); err != nil {
+		return 1
+	}
+	return 0
+}
+
+func writeTerminal(w io.Writer, v schema.Verse) int {
+	fmt.Fprintln(w, injector.DisplayRef(v))
+	if v.Source.Attribution != "" {
+		fmt.Fprintf(w, "(%s)\n", v.Source.Attribution)
+	}
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, v.Text)
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "checksum: %s\n", v.ChecksumSHA256)
+	return 0
+}
+
+// runLookupFromPrompt implements `scripture-mcp lookup-from-prompt`. It
+// reads the user prompt from stdin, scans for a marker, and emits a JSON
+// envelope on stdout suitable for both Claude Code's UserPromptExpansion
+// and Codex's UserPromptSubmit hooks.
+//
+// Recognized markers (case-insensitive on the keyword, single match wins;
+// the leftmost marker is used):
+//
+//   - Slash form (Claude Code): leading `/bible John 3:16` ...
+//   - Inline form (Codex):      ... `[[bible:John 3:16]]` ...
+//
+// If no marker is present, exits 0 silently with no output. The
+// integration intent is that each agent's hook pipes the user's prompt
+// to this command and merges the emitted `additionalContext` field into
+// the model's input for the current turn only.
+func runLookupFromPrompt(args []string, s Streams) int {
+	fs := flag.NewFlagSet("lookup-from-prompt", flag.ContinueOnError)
+	fs.SetOutput(s.Err)
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	body, err := io.ReadAll(s.In)
+	if err != nil {
+		fmt.Fprintln(s.Err, "error:", err)
+		return 1
+	}
+	prompt := normalizePromptInput(body)
+	tradition, ref, ok := scanMarker(prompt)
+	if !ok {
+		// No marker → silent exit so the hook adds nothing.
+		return 0
+	}
+	v, err := resolveTrailing(tradition, ref)
+	if err != nil {
+		// Soft-fail: hooks should never break the user's prompt. Log to
+		// stderr (visible to the agent's debug logs) and exit 0 with no
+		// additionalContext.
+		fmt.Fprintf(s.Err, "verse-driven: lookup failed for %q %q: %v\n", tradition, ref, err)
+		return 0
+	}
+	out := struct {
+		AdditionalContext string `json:"additionalContext"`
+	}{AdditionalContext: injector.Envelope(v)}
+	enc := json.NewEncoder(s.Out)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(out); err != nil {
+		return 1
+	}
+	return 0
+}
+
+// normalizePromptInput accepts either a raw prompt string or a JSON object
+// with a "prompt" or "user_prompt" field (the form Claude Code / Codex
+// hooks send on stdin).
+func normalizePromptInput(b []byte) string {
+	trimmed := strings.TrimSpace(string(b))
+	if trimmed == "" {
+		return ""
+	}
+	if trimmed[0] == '{' {
+		var obj map[string]any
+		if err := json.Unmarshal([]byte(trimmed), &obj); err == nil {
+			for _, k := range []string{"prompt", "user_prompt", "input", "text"} {
+				if s, ok := obj[k].(string); ok && s != "" {
+					return s
+				}
+			}
+		}
+	}
+	return trimmed
+}
+
+var (
+	// /bible John 3:16 ...   /dao 11   /sutra   /quran 2:255
+	// The trailing capture is everything to the end of the line; the
+	// caller (resolveTrailing) trims tokens from the right until the
+	// resolver accepts what remains.
+	reSlashMarker = regexp.MustCompile(`(?i)(?:^|\s)/(bible|dao|sutra|quran)(?:[ \t]+([^\n]*))?`)
+	// [[bible:John 3:16]]   [[dao:11]]   [[sutra]]   [[quran:2:255]]
+	reInlineMarker = regexp.MustCompile(`(?i)\[\[(bible|dao|sutra|quran)(?::([^\]\n]*))?\]\]`)
+)
+
+// resolveTrailing attempts to resolve a reference, progressively trimming
+// whitespace-separated tokens from the right end of `rest` until the
+// resolver accepts what remains. This lets a marker like
+// `/bible John 3:16 Refactor X.` extract just the reference and leave the
+// rest of the prompt untouched, without the marker scanner having to
+// know what a reference looks like (the resolver is the source of truth).
+//
+// The candidate string passed to the resolver depends on tradition: bible
+// references are self-describing (the book name carries the tradition);
+// dao and quran require a tradition keyword prefix; sutra takes no
+// chapter/verse and ignores trailing input.
+func resolveTrailing(tradition, rest string) (schema.Verse, error) {
+	if tradition == "sutra" {
+		return resolveAndLookup("sutra")
+	}
+	cur := strings.TrimSpace(rest)
+	candidate := func() string {
+		switch tradition {
+		case "bible":
+			return cur
+		default: // dao, quran
+			if cur == "" {
+				return tradition
+			}
+			return tradition + " " + cur
+		}
+	}
+	var lastErr error
+	for {
+		c := candidate()
+		if c == "" {
+			break
+		}
+		v, err := resolveAndLookup(c)
+		if err == nil {
+			return v, nil
+		}
+		lastErr = err
+		idx := strings.LastIndexAny(cur, " \t")
+		if idx < 0 {
+			break
+		}
+		cur = strings.TrimSpace(cur[:idx])
+	}
+	if lastErr == nil {
+		lastErr = fmt.Errorf("could not resolve %s reference", tradition)
+	}
+	return schema.Verse{}, lastErr
+}
+
+// scanMarker extracts (tradition, ref) from the leftmost marker in prompt.
+// Returns (_, _, false) when no marker is present.
+func scanMarker(prompt string) (tradition, ref string, ok bool) {
+	type hit struct {
+		idx        int
+		tradition  string
+		ref        string
+	}
+	var best *hit
+	if m := reSlashMarker.FindStringSubmatchIndex(prompt); m != nil {
+		// FindStringSubmatchIndex returns indices of the entire match and submatches.
+		full := strings.TrimSpace(prompt[m[0]:m[1]])
+		sub := reSlashMarker.FindStringSubmatch(full)
+		best = &hit{idx: m[0], tradition: strings.ToLower(sub[1]), ref: strings.TrimSpace(sub[2])}
+	}
+	if m := reInlineMarker.FindStringSubmatchIndex(prompt); m != nil {
+		sub := reInlineMarker.FindStringSubmatch(prompt[m[0]:m[1]])
+		if best == nil || m[0] < best.idx {
+			best = &hit{idx: m[0], tradition: strings.ToLower(sub[1]), ref: strings.TrimSpace(sub[2])}
+		}
+	}
+	if best == nil {
+		return "", "", false
+	}
+	// For "sutra" with no ref, that's still valid (whole text).
+	if best.ref == "" && best.tradition != "sutra" {
+		// e.g. "/bible" alone — invalid. Treat as no marker.
+		return "", "", false
+	}
+	return best.tradition, best.ref, true
+}

--- a/internal/cli/lookup_test.go
+++ b/internal/cli/lookup_test.go
@@ -1,0 +1,168 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/MiaoDX/verse-driven/internal/schema"
+)
+
+func TestRunLookupJSONHappy(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	code := runLookup([]string{"--format=json", "John 3:16"}, Streams{Out: &out, Err: &errBuf})
+	if code != 0 {
+		t.Fatalf("exit %d, stderr=%q", code, errBuf.String())
+	}
+	var v schema.Verse
+	if err := json.Unmarshal(out.Bytes(), &v); err != nil {
+		t.Fatalf("output is not JSON Verse: %v\n%s", err, out.String())
+	}
+	if v.ID != "bible.kjv.john.3.16" {
+		t.Errorf("id %q, want bible.kjv.john.3.16", v.ID)
+	}
+	if v.ChecksumSHA256 == "" {
+		t.Error("checksum_sha256 missing in JSON output")
+	}
+	if v.Source.Provider == "" {
+		t.Error("source.provider missing")
+	}
+}
+
+func TestRunLookupJSONIsDefault(t *testing.T) {
+	var out bytes.Buffer
+	if code := runLookup([]string{"道德经 11"}, Streams{Out: &out, Err: &bytes.Buffer{}}); code != 0 {
+		t.Fatalf("exit %d", code)
+	}
+	if !json.Valid(out.Bytes()) {
+		t.Errorf("default format must produce valid JSON; got: %s", out.String())
+	}
+}
+
+func TestRunLookupTextFormat(t *testing.T) {
+	var out bytes.Buffer
+	if code := runLookup([]string{"--format=text", "John 3:16"}, Streams{Out: &out, Err: &bytes.Buffer{}}); code != 0 {
+		t.Fatalf("exit %d", code)
+	}
+	s := out.String()
+	if !strings.Contains(s, "John 3:16") {
+		t.Errorf("text output missing display ref:\n%s", s)
+	}
+	if !strings.Contains(s, "checksum:") {
+		t.Errorf("text output missing checksum line:\n%s", s)
+	}
+}
+
+func TestRunLookupAmbiguous(t *testing.T) {
+	var errBuf bytes.Buffer
+	code := runLookup([]string{"3:16"}, Streams{Out: &bytes.Buffer{}, Err: &errBuf})
+	if code != 3 {
+		t.Errorf("exit code = %d, want 3 (ambiguous)\nstderr=%s", code, errBuf.String())
+	}
+	if !strings.Contains(errBuf.String(), "ambiguous") {
+		t.Errorf("stderr should mention ambiguity:\n%s", errBuf.String())
+	}
+}
+
+func TestRunLookupUnrecognized(t *testing.T) {
+	var errBuf bytes.Buffer
+	code := runLookup([]string{"some gibberish"}, Streams{Out: &bytes.Buffer{}, Err: &errBuf})
+	if code != 1 {
+		t.Errorf("exit code = %d, want 1\nstderr=%s", code, errBuf.String())
+	}
+}
+
+func TestRunLookupMissingArg(t *testing.T) {
+	var errBuf bytes.Buffer
+	if code := runLookup([]string{}, Streams{Out: &bytes.Buffer{}, Err: &errBuf}); code != 2 {
+		t.Errorf("exit code = %d, want 2 (usage)", code)
+	}
+}
+
+func TestRunLookupSutraIsApiOnly(t *testing.T) {
+	var errBuf bytes.Buffer
+	if code := runLookup([]string{"心经"}, Streams{Out: &bytes.Buffer{}, Err: &errBuf}); code != 1 {
+		t.Errorf("exit code = %d, want 1", code)
+	}
+	if !strings.Contains(errBuf.String(), "not bundled") {
+		t.Errorf("stderr should explain api-only state:\n%s", errBuf.String())
+	}
+}
+
+func TestLookupFromPromptSlashMarker(t *testing.T) {
+	in := strings.NewReader("/bible John 3:16 Refactor the cron-string scheduler.")
+	var out, errBuf bytes.Buffer
+	if code := runLookupFromPrompt(nil, Streams{In: in, Out: &out, Err: &errBuf}); code != 0 {
+		t.Fatalf("exit %d, stderr=%s", code, errBuf.String())
+	}
+	var resp struct {
+		AdditionalContext string `json:"additionalContext"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &resp); err != nil {
+		t.Fatalf("output not JSON: %v\n%s", err, out.String())
+	}
+	if !strings.Contains(resp.AdditionalContext, "<scripture_card>") {
+		t.Errorf("envelope missing scripture_card tags: %s", resp.AdditionalContext)
+	}
+	if !strings.Contains(resp.AdditionalContext, "John 3:16") {
+		t.Errorf("envelope missing display ref: %s", resp.AdditionalContext)
+	}
+}
+
+func TestLookupFromPromptInlineMarker(t *testing.T) {
+	in := strings.NewReader("Please [[dao:11]] keep going on the helper.")
+	var out bytes.Buffer
+	if code := runLookupFromPrompt(nil, Streams{In: in, Out: &out, Err: &bytes.Buffer{}}); code != 0 {
+		t.Fatalf("exit %d", code)
+	}
+	var resp struct {
+		AdditionalContext string `json:"additionalContext"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &resp); err != nil {
+		t.Fatalf("output not JSON: %v\n%s", err, out.String())
+	}
+	if !strings.Contains(resp.AdditionalContext, "道德经") {
+		t.Errorf("dao envelope missing display ref:\n%s", resp.AdditionalContext)
+	}
+}
+
+func TestLookupFromPromptJSONInputForm(t *testing.T) {
+	body, _ := json.Marshal(map[string]string{"prompt": "/bible John 3:16 do the thing"})
+	var out bytes.Buffer
+	code := runLookupFromPrompt(nil, Streams{In: bytes.NewReader(body), Out: &out, Err: &bytes.Buffer{}})
+	if code != 0 {
+		t.Fatalf("exit %d", code)
+	}
+	if out.Len() == 0 {
+		t.Fatal("expected JSON output for valid marker, got empty")
+	}
+}
+
+func TestLookupFromPromptNoMarkerSilent(t *testing.T) {
+	var out bytes.Buffer
+	code := runLookupFromPrompt(nil, Streams{
+		In:  strings.NewReader("just refactor this no marker here"),
+		Out: &out,
+		Err: &bytes.Buffer{},
+	})
+	if code != 0 {
+		t.Errorf("exit %d, want 0 (silent)", code)
+	}
+	if out.Len() != 0 {
+		t.Errorf("expected no output, got: %q", out.String())
+	}
+}
+
+func TestLookupFromPromptUnresolvableMarkerSoftFails(t *testing.T) {
+	// /bible without a ref → bare marker → no marker treated as no-op
+	in := strings.NewReader("/bible")
+	var out, errBuf bytes.Buffer
+	code := runLookupFromPrompt(nil, Streams{In: in, Out: &out, Err: &errBuf})
+	if code != 0 {
+		t.Errorf("exit %d, want 0", code)
+	}
+	if out.Len() != 0 {
+		t.Errorf("expected no output, got: %q", out.String())
+	}
+}

--- a/internal/cli/recap.go
+++ b/internal/cli/recap.go
@@ -1,0 +1,136 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"math/rand"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/MiaoDX/verse-driven/internal/injector"
+	"github.com/MiaoDX/verse-driven/internal/packs"
+	"github.com/MiaoDX/verse-driven/internal/schema"
+)
+
+// runRecap implements `scripture-mcp recap [--tradition=<t>] [--terminal]
+// [--first-letter] [--seed=<n>]`.
+//
+// Picks one verse from the requested tradition (default: any bundled
+// tradition) and prints it to stdout. Output goes to the user's terminal
+// only — by design, recap is invoked in contexts where its stdout never
+// flows back into a model_call input (Claude Stop hook, Codex shell
+// wrapper). See plan.md §2.1.
+func runRecap(args []string, s Streams) int {
+	fs := flag.NewFlagSet("recap", flag.ContinueOnError)
+	fs.SetOutput(s.Err)
+	tradition := fs.String("tradition", "", "limit to one tradition: bible|dao|sutra|quran")
+	terminal := fs.Bool("terminal", false, "print pretty terminal output (default behavior)")
+	firstLetter := fs.Bool("first-letter", false, "mask all-but-first character of each word/character (memory mode)")
+	seed := fs.Int64("seed", 0, "deterministic seed; 0 = time-based (default)")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	_ = terminal // accepted for compatibility; the CLI prints to terminal regardless
+
+	v, ok := pickRecapVerse(*tradition, *seed)
+	if !ok {
+		fmt.Fprintln(s.Err, "error: no bundled verses available for tradition", *tradition)
+		return 1
+	}
+	body := v.Text
+	if *firstLetter {
+		body = firstLetterMask(body)
+	}
+	fmt.Fprintln(s.Out, "📖", injector.DisplayRef(v))
+	if v.Source.Attribution != "" {
+		fmt.Fprintf(s.Out, "(%s)\n", v.Source.Attribution)
+	}
+	fmt.Fprintln(s.Out)
+	fmt.Fprintln(s.Out, body)
+	return 0
+}
+
+// pickRecapVerse selects one bundled verse, optionally filtered to a
+// single tradition. Returns (_, false) when no bundled verses match.
+//
+// Selection strategy: uniform random across all eligible verses. seed=0
+// uses time-based randomness; non-zero seed makes the call deterministic
+// (used by tests and by future spaced-repetition selectors).
+func pickRecapVerse(tradition string, seed int64) (schema.Verse, bool) {
+	var pool []schema.Verse
+	r := packs.All()
+	for _, name := range r.Names() {
+		p := r.Pack(name)
+		if p.Meta.InclusionMode != "" && p.Meta.InclusionMode != "bundled" {
+			continue
+		}
+		if tradition != "" && p.Meta.Tradition != tradition {
+			continue
+		}
+		pool = append(pool, p.Verses()...)
+	}
+	if len(pool) == 0 {
+		return schema.Verse{}, false
+	}
+	if seed == 0 {
+		seed = time.Now().UnixNano()
+	}
+	rng := rand.New(rand.NewSource(seed))
+	return pool[rng.Intn(len(pool))], true
+}
+
+// firstLetterMask returns a memory-pattern view of s. For each word made
+// of ASCII letters we keep the first letter and replace the remaining
+// letters with `_`. Whitespace and punctuation pass through. CJK runs are
+// rendered character-by-character with each kept and `_` separators
+// between them, so "三十辐" → "三 _ _" (helps with rote recall).
+func firstLetterMask(s string) string {
+	var b strings.Builder
+	for _, line := range strings.Split(s, "\n") {
+		b.WriteString(maskLine(line))
+		b.WriteByte('\n')
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func maskLine(line string) string {
+	var b strings.Builder
+	inWord := false
+	wordHasFirst := false
+	for _, r := range line {
+		switch {
+		case unicode.Is(unicode.Han, r):
+			if inWord {
+				inWord = false
+				wordHasFirst = false
+			}
+			b.WriteRune(r)
+			b.WriteString(" _")
+		case isWordRune(r):
+			if !inWord {
+				inWord = true
+				wordHasFirst = false
+			}
+			if !wordHasFirst {
+				b.WriteRune(r)
+				wordHasFirst = true
+			} else {
+				b.WriteRune('_')
+			}
+		default:
+			inWord = false
+			wordHasFirst = false
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+func isWordRune(r rune) bool {
+	if r > unicode.MaxASCII {
+		return unicode.IsLetter(r)
+	}
+	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z')
+}
+

--- a/internal/cli/recap_test.go
+++ b/internal/cli/recap_test.go
@@ -1,0 +1,80 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestRecapDeterministicWithSeed(t *testing.T) {
+	var a, b bytes.Buffer
+	for _, w := range []*bytes.Buffer{&a, &b} {
+		if code := runRecap([]string{"--seed=42"}, Streams{Out: w, Err: &bytes.Buffer{}}); code != 0 {
+			t.Fatalf("exit %d", code)
+		}
+	}
+	if a.String() != b.String() {
+		t.Errorf("same seed → different output:\nA: %s\nB: %s", a.String(), b.String())
+	}
+}
+
+func TestRecapTraditionFilter(t *testing.T) {
+	var out bytes.Buffer
+	if code := runRecap([]string{"--tradition=dao", "--seed=1"}, Streams{Out: &out, Err: &bytes.Buffer{}}); code != 0 {
+		t.Fatalf("exit %d", code)
+	}
+	if !strings.Contains(out.String(), "道德经") {
+		t.Errorf("dao recap should mention 道德经:\n%s", out.String())
+	}
+}
+
+func TestRecapBibleHasAttribution(t *testing.T) {
+	var out bytes.Buffer
+	if code := runRecap([]string{"--tradition=bible", "--seed=7"}, Streams{Out: &out, Err: &bytes.Buffer{}}); code != 0 {
+		t.Fatalf("exit %d", code)
+	}
+	s := out.String()
+	if !strings.Contains(s, "📖") {
+		t.Errorf("recap output missing scripture marker: %s", s)
+	}
+	if !strings.Contains(s, "King James Version") {
+		t.Errorf("bible recap missing KJV attribution: %s", s)
+	}
+}
+
+func TestRecapFirstLetterMode(t *testing.T) {
+	var out bytes.Buffer
+	if code := runRecap([]string{"--tradition=bible", "--seed=7", "--first-letter"}, Streams{Out: &out, Err: &bytes.Buffer{}}); code != 0 {
+		t.Fatalf("exit %d", code)
+	}
+	// First-letter masking replaces letters past the first with `_`.
+	// The masked body should contain underscores; without masking the
+	// output never contains the standalone underscore character.
+	s := out.String()
+	if !strings.Contains(s, "_") {
+		t.Errorf("first-letter mode should produce underscores: %s", s)
+	}
+}
+
+func TestRecapUnknownTradition(t *testing.T) {
+	var errBuf bytes.Buffer
+	code := runRecap([]string{"--tradition=nonsense", "--seed=1"}, Streams{Out: &bytes.Buffer{}, Err: &errBuf})
+	if code != 1 {
+		t.Errorf("exit %d, want 1 for unknown tradition; stderr=%q", code, errBuf.String())
+	}
+}
+
+func TestFirstLetterMaskASCII(t *testing.T) {
+	got := firstLetterMask("For God so loved the world")
+	want := "F__ G__ s_ l____ t__ w____"
+	if got != want {
+		t.Errorf("got %q\nwant %q", got, want)
+	}
+}
+
+func TestFirstLetterMaskHan(t *testing.T) {
+	got := firstLetterMask("三十辐共一毂")
+	if !strings.Contains(got, "三 _") {
+		t.Errorf("Han masking incorrect: %q", got)
+	}
+}

--- a/internal/injector/doc.go
+++ b/internal/injector/doc.go
@@ -1,3 +1,0 @@
-// Package injector renders the temporary, one-turn scripture envelope
-// described in plan.md §6.3. Implementation lands when adapters wire it up.
-package injector

--- a/internal/injector/envelope.go
+++ b/internal/injector/envelope.go
@@ -1,0 +1,62 @@
+// Package injector renders the temporary, one-turn scripture envelope
+// described in plan.md §6.3. The envelope is the only place a verse body
+// is rendered into model-visible context, and it is rendered on a per-turn
+// basis only.
+package injector
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/MiaoDX/verse-driven/internal/schema"
+)
+
+// Envelope wraps a verse in the plan §6.3 reflection-context block.
+//
+// The output is plain text with a <scripture_card>...</scripture_card>
+// island. The wrapping language (1) marks the block as one-turn-only and
+// (2) instructs the model not to alter engineering rigor or preach. The
+// model-side reinforcement lives in the output style (issue #5); the
+// envelope's job here is to mark the block clearly.
+func Envelope(v schema.Verse) string {
+	var b strings.Builder
+	b.WriteString("Temporary reflection context for this turn only.\n")
+	b.WriteString("Do not alter engineering rigor, verification, testing, or safety behavior.\n")
+	b.WriteString("Use the scripture only as an optional reflective frame.\n")
+	b.WriteString("Quote verbatim if you mention it. Do not preach.\n\n")
+	b.WriteString("<scripture_card>\n")
+	b.WriteString(v.Text)
+	b.WriteString("\n\n— ")
+	b.WriteString(DisplayRef(v))
+	if v.Source.Attribution != "" {
+		b.WriteString(", ")
+		b.WriteString(v.Source.Attribution)
+	}
+	b.WriteString("\n</scripture_card>\n")
+	return b.String()
+}
+
+// DisplayRef formats a verse's canonical reference for human display.
+// Prefers DisplayRef["en"] when set; falls back to a tradition-specific
+// rendering otherwise.
+func DisplayRef(v schema.Verse) string {
+	if v.DisplayRef != nil {
+		if s, ok := v.DisplayRef["en"]; ok && s != "" {
+			return s
+		}
+	}
+	switch v.Tradition {
+	case "bible":
+		if v.CanonicalRef.VerseEnd != 0 && v.CanonicalRef.VerseEnd != v.CanonicalRef.VerseStart {
+			return fmt.Sprintf("%s %d:%d-%d", v.CanonicalRef.Book, v.CanonicalRef.Chapter, v.CanonicalRef.VerseStart, v.CanonicalRef.VerseEnd)
+		}
+		return fmt.Sprintf("%s %d:%d", v.CanonicalRef.Book, v.CanonicalRef.Chapter, v.CanonicalRef.VerseStart)
+	case "dao":
+		return fmt.Sprintf("道德经 第%d章", v.CanonicalRef.Chapter)
+	case "sutra":
+		return "心经"
+	case "quran":
+		return fmt.Sprintf("Quran %d:%d", v.CanonicalRef.Chapter, v.CanonicalRef.VerseStart)
+	}
+	return v.ID
+}

--- a/internal/injector/envelope_test.go
+++ b/internal/injector/envelope_test.go
@@ -1,0 +1,77 @@
+package injector
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/MiaoDX/verse-driven/internal/schema"
+)
+
+func TestEnvelopeWrapsScriptureCard(t *testing.T) {
+	v := schema.Verse{
+		ID:        "bible.kjv.john.3.16",
+		Tradition: "bible",
+		Lang:      "en",
+		Work:      "KJV",
+		CanonicalRef: schema.CanonicalRef{
+			Book: "John", Chapter: 3, VerseStart: 16,
+		},
+		Text:           "TXT",
+		Source:         schema.Source{Provider: "PG", License: "PD", Attribution: "KJV"},
+		ChecksumSHA256: strings.Repeat("0", 64),
+	}
+	out := Envelope(v)
+	for _, want := range []string{
+		"Temporary reflection context",
+		"Do not preach",
+		"<scripture_card>",
+		"TXT",
+		"John 3:16",
+		"KJV",
+		"</scripture_card>",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("envelope missing %q\n--- got ---\n%s", want, out)
+		}
+	}
+}
+
+func TestDisplayRefByTradition(t *testing.T) {
+	cases := []struct {
+		v    schema.Verse
+		want string
+	}{
+		{
+			v:    schema.Verse{Tradition: "bible", CanonicalRef: schema.CanonicalRef{Book: "John", Chapter: 3, VerseStart: 16}},
+			want: "John 3:16",
+		},
+		{
+			v:    schema.Verse{Tradition: "bible", CanonicalRef: schema.CanonicalRef{Book: "John", Chapter: 3, VerseStart: 16, VerseEnd: 18}},
+			want: "John 3:16-18",
+		},
+		{
+			v:    schema.Verse{Tradition: "dao", CanonicalRef: schema.CanonicalRef{Chapter: 11, VerseStart: 1}},
+			want: "道德经 第11章",
+		},
+		{
+			v:    schema.Verse{Tradition: "sutra"},
+			want: "心经",
+		},
+		{
+			v:    schema.Verse{Tradition: "quran", CanonicalRef: schema.CanonicalRef{Chapter: 2, VerseStart: 255}},
+			want: "Quran 2:255",
+		},
+		{
+			v: schema.Verse{
+				Tradition:  "bible",
+				DisplayRef: map[string]string{"en": "Romans 8:28 (custom)"},
+			},
+			want: "Romans 8:28 (custom)",
+		},
+	}
+	for _, c := range cases {
+		if got := DisplayRef(c.v); got != c.want {
+			t.Errorf("DisplayRef(%+v) = %q, want %q", c.v.Tradition, got, c.want)
+		}
+	}
+}

--- a/internal/mcp/doc.go
+++ b/internal/mcp/doc.go
@@ -1,2 +1,0 @@
-// Package mcp implements the stdio MCP server. Lands in issue #4.
-package mcp

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1,0 +1,447 @@
+// Package mcp implements a minimal stdio MCP server for the
+// scripture-mcp binary. It exposes four tools: lookup, search, random,
+// and list_traditions. The wire format is newline-delimited JSON-RPC 2.0
+// over stdio (the MCP stdio transport).
+//
+// We deliberately do not depend on a third-party MCP SDK: the surface we
+// need is small (3 methods, 4 tools, no resources/prompts), and pulling
+// in an SDK doubles the dependency footprint of a project that today has
+// zero non-stdlib deps.
+package mcp
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math/rand"
+	"strings"
+	"time"
+
+	"github.com/MiaoDX/verse-driven/internal/packs"
+	"github.com/MiaoDX/verse-driven/internal/resolver"
+	"github.com/MiaoDX/verse-driven/internal/schema"
+)
+
+const (
+	// ProtocolVersion is the MCP protocol revision this server speaks back
+	// to clients during the initialize handshake. Clients that report a
+	// different version still get a response — they are expected to
+	// negotiate based on what we return rather than refuse outright.
+	ProtocolVersion = "2024-11-05"
+
+	ServerName    = "scripture-mcp"
+	ServerVersion = "0.1.0"
+)
+
+// Lookuper is the slice of the verse registry the server depends on. The
+// concrete *packs.Registry satisfies this; a fake satisfies it in tests.
+type Lookuper interface {
+	Lookup(id string) (schema.Verse, bool)
+	Pack(name packs.PackName) *packs.Pack
+	Names() []packs.PackName
+}
+
+// Server is one stdio MCP session. Construct via New, then call Serve.
+type Server struct {
+	registry Lookuper
+	rng      *rand.Rand
+}
+
+// New builds a Server backed by the given verse registry. Pass packs.All()
+// for production; pass a stub in tests.
+func New(reg Lookuper) *Server {
+	return &Server{
+		registry: reg,
+		rng:      rand.New(rand.NewSource(time.Now().UnixNano())),
+	}
+}
+
+// Serve reads NDJSON from r, dispatches each request, and writes the
+// reply to w. It returns when r returns io.EOF or ctx is canceled.
+func (s *Server) Serve(ctx context.Context, r io.Reader, w io.Writer) error {
+	br := bufio.NewReaderSize(r, 1<<16)
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		line, err := br.ReadBytes('\n')
+		if len(line) > 0 {
+			if resp, ok := s.handleLine(line); ok {
+				if _, werr := w.Write(append(resp, '\n')); werr != nil {
+					return werr
+				}
+			}
+		}
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return err
+		}
+	}
+}
+
+type rpcRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+type rpcResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Result  any             `json:"result,omitempty"`
+	Error   *rpcError       `json:"error,omitempty"`
+}
+
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Data    any    `json:"data,omitempty"`
+}
+
+// JSON-RPC error codes. -32600..-32603 are reserved by the spec; we use
+// the standard ones plus a method-not-found for unknown tools.
+const (
+	codeParseError     = -32700
+	codeInvalidRequest = -32600
+	codeMethodNotFound = -32601
+	codeInvalidParams  = -32602
+	codeInternalError  = -32603
+)
+
+// handleLine parses one NDJSON line and returns (response, true) when a
+// reply must be written, or (_, false) for notifications and blank lines.
+func (s *Server) handleLine(line []byte) ([]byte, bool) {
+	trimmed := strings.TrimSpace(string(line))
+	if trimmed == "" {
+		return nil, false
+	}
+	var req rpcRequest
+	if err := json.Unmarshal([]byte(trimmed), &req); err != nil {
+		return marshalResp(rpcResponse{
+			JSONRPC: "2.0",
+			Error:   &rpcError{Code: codeParseError, Message: "parse error: " + err.Error()},
+		}), true
+	}
+	// Notifications have no id; we never reply to them.
+	isNotification := len(req.ID) == 0
+
+	resp := s.dispatch(req)
+	if isNotification {
+		return nil, false
+	}
+	resp.JSONRPC = "2.0"
+	resp.ID = req.ID
+	return marshalResp(resp), true
+}
+
+func marshalResp(r rpcResponse) []byte {
+	b, err := json.Marshal(r)
+	if err != nil {
+		// Marshalling our own struct should never fail; if it does, emit a
+		// hard-coded fallback so the client at least sees a JSON-RPC error.
+		return []byte(`{"jsonrpc":"2.0","error":{"code":-32603,"message":"marshal failed"}}`)
+	}
+	return b
+}
+
+func (s *Server) dispatch(req rpcRequest) rpcResponse {
+	switch req.Method {
+	case "initialize":
+		return rpcResponse{Result: s.handleInitialize()}
+	case "initialized", "notifications/initialized":
+		return rpcResponse{} // notification — caller drops it
+	case "ping":
+		return rpcResponse{Result: map[string]any{}}
+	case "tools/list":
+		return rpcResponse{Result: s.handleToolsList()}
+	case "tools/call":
+		return s.handleToolsCall(req.Params)
+	case "shutdown":
+		return rpcResponse{Result: map[string]any{}}
+	default:
+		return rpcResponse{Error: &rpcError{Code: codeMethodNotFound, Message: "unknown method: " + req.Method}}
+	}
+}
+
+func (s *Server) handleInitialize() any {
+	return map[string]any{
+		"protocolVersion": ProtocolVersion,
+		"serverInfo": map[string]any{
+			"name":    ServerName,
+			"version": ServerVersion,
+		},
+		"capabilities": map[string]any{
+			"tools": map[string]any{},
+		},
+	}
+}
+
+type toolDef struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	InputSchema map[string]any `json:"inputSchema"`
+}
+
+func (s *Server) handleToolsList() any {
+	return map[string]any{"tools": toolDefinitions()}
+}
+
+func toolDefinitions() []toolDef {
+	return []toolDef{
+		{
+			Name:        "lookup",
+			Description: "Look up a single verse by free-form reference (e.g. \"John 3:16\", \"道德经第十一章\", \"Quran 2:255\"). Returns the canonical verse with checksum and source metadata.",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"ref": map[string]any{
+						"type":        "string",
+						"description": "Free-form scripture reference.",
+					},
+				},
+				"required": []string{"ref"},
+			},
+		},
+		{
+			Name:        "search",
+			Description: "Search for verses whose text contains the query substring. Optional `tradition` filter (bible|dao|sutra|quran). Returns up to `limit` verses (default 10).",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"query":     map[string]any{"type": "string", "description": "Substring to search for."},
+					"tradition": map[string]any{"type": "string", "description": "Restrict to one tradition: bible|dao|sutra|quran."},
+					"limit":     map[string]any{"type": "integer", "description": "Max results (default 10, max 50)."},
+				},
+				"required": []string{"query"},
+			},
+		},
+		{
+			Name:        "random",
+			Description: "Return one randomly-selected verse. Optional `tradition` filter (bible|dao|sutra|quran).",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"tradition": map[string]any{"type": "string", "description": "Restrict to one tradition: bible|dao|sutra|quran."},
+				},
+			},
+		},
+		{
+			Name:        "list_traditions",
+			Description: "List the bundled traditions, with verse counts and inclusion mode.",
+			InputSchema: map[string]any{
+				"type":       "object",
+				"properties": map[string]any{},
+			},
+		},
+	}
+}
+
+func (s *Server) handleToolsCall(raw json.RawMessage) rpcResponse {
+	var p struct {
+		Name      string          `json:"name"`
+		Arguments json.RawMessage `json:"arguments"`
+	}
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return rpcResponse{Error: &rpcError{Code: codeInvalidParams, Message: "invalid params: " + err.Error()}}
+	}
+	switch p.Name {
+	case "lookup":
+		return s.toolLookup(p.Arguments)
+	case "search":
+		return s.toolSearch(p.Arguments)
+	case "random":
+		return s.toolRandom(p.Arguments)
+	case "list_traditions":
+		return s.toolListTraditions()
+	default:
+		return rpcResponse{Error: &rpcError{Code: codeMethodNotFound, Message: "unknown tool: " + p.Name}}
+	}
+}
+
+func (s *Server) toolLookup(raw json.RawMessage) rpcResponse {
+	var args struct {
+		Ref string `json:"ref"`
+	}
+	if err := json.Unmarshal(raw, &args); err != nil {
+		return rpcResponse{Error: &rpcError{Code: codeInvalidParams, Message: "invalid arguments: " + err.Error()}}
+	}
+	if strings.TrimSpace(args.Ref) == "" {
+		return rpcResponse{Error: &rpcError{Code: codeInvalidParams, Message: "ref is required"}}
+	}
+	v, err := s.lookupByRef(args.Ref)
+	if err != nil {
+		return errorToolResult(err)
+	}
+	return verseToolResult(v)
+}
+
+func (s *Server) lookupByRef(ref string) (schema.Verse, error) {
+	r, err := resolver.Resolve(ref)
+	if err != nil {
+		return schema.Verse{}, err
+	}
+	id, err := packs.ReferenceID(r)
+	if err != nil {
+		return schema.Verse{}, err
+	}
+	v, ok := s.registry.Lookup(id)
+	if !ok {
+		if r.Tradition == resolver.TraditionSutra || r.Tradition == resolver.TraditionQuran {
+			return schema.Verse{}, fmt.Errorf("%w: %s", packs.ErrNotBundled, r.Tradition)
+		}
+		return schema.Verse{}, fmt.Errorf("verse not found: %s", id)
+	}
+	return v, nil
+}
+
+func (s *Server) toolSearch(raw json.RawMessage) rpcResponse {
+	var args struct {
+		Query     string `json:"query"`
+		Tradition string `json:"tradition"`
+		Limit     int    `json:"limit"`
+	}
+	if err := json.Unmarshal(raw, &args); err != nil {
+		return rpcResponse{Error: &rpcError{Code: codeInvalidParams, Message: "invalid arguments: " + err.Error()}}
+	}
+	q := strings.TrimSpace(args.Query)
+	if q == "" {
+		return rpcResponse{Error: &rpcError{Code: codeInvalidParams, Message: "query is required"}}
+	}
+	limit := args.Limit
+	if limit <= 0 {
+		limit = 10
+	}
+	if limit > 50 {
+		limit = 50
+	}
+	matches := s.searchVerses(q, args.Tradition, limit)
+	return versesToolResult(matches)
+}
+
+func (s *Server) searchVerses(query, tradition string, limit int) []schema.Verse {
+	q := strings.ToLower(query)
+	var out []schema.Verse
+	for _, name := range s.registry.Names() {
+		p := s.registry.Pack(name)
+		if tradition != "" && p.Meta.Tradition != tradition {
+			continue
+		}
+		for _, v := range p.Verses() {
+			if strings.Contains(strings.ToLower(v.Text), q) {
+				out = append(out, v)
+				if len(out) >= limit {
+					return out
+				}
+			}
+		}
+	}
+	return out
+}
+
+func (s *Server) toolRandom(raw json.RawMessage) rpcResponse {
+	var args struct {
+		Tradition string `json:"tradition"`
+	}
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &args); err != nil {
+			return rpcResponse{Error: &rpcError{Code: codeInvalidParams, Message: "invalid arguments: " + err.Error()}}
+		}
+	}
+	v, ok := s.pickRandom(args.Tradition)
+	if !ok {
+		return errorToolResult(fmt.Errorf("no bundled verses available%s", traditionSuffix(args.Tradition)))
+	}
+	return verseToolResult(v)
+}
+
+func traditionSuffix(t string) string {
+	if t == "" {
+		return ""
+	}
+	return " for tradition " + t
+}
+
+func (s *Server) pickRandom(tradition string) (schema.Verse, bool) {
+	var pool []schema.Verse
+	for _, name := range s.registry.Names() {
+		p := s.registry.Pack(name)
+		if p.Meta.InclusionMode != "" && p.Meta.InclusionMode != "bundled" {
+			continue
+		}
+		if tradition != "" && p.Meta.Tradition != tradition {
+			continue
+		}
+		pool = append(pool, p.Verses()...)
+	}
+	if len(pool) == 0 {
+		return schema.Verse{}, false
+	}
+	return pool[s.rng.Intn(len(pool))], true
+}
+
+func (s *Server) toolListTraditions() rpcResponse {
+	type entry struct {
+		Tradition     string `json:"tradition"`
+		Work          string `json:"work"`
+		Lang          string `json:"lang"`
+		VerseCount    int    `json:"verse_count"`
+		InclusionMode string `json:"inclusion_mode"`
+		Source        string `json:"source"`
+	}
+	var entries []entry
+	for _, name := range s.registry.Names() {
+		p := s.registry.Pack(name)
+		entries = append(entries, entry{
+			Tradition:     p.Meta.Tradition,
+			Work:          p.Meta.Work,
+			Lang:          p.Meta.Lang,
+			VerseCount:    len(p.Verses()),
+			InclusionMode: p.Meta.InclusionMode,
+			Source:        p.Meta.Provider,
+		})
+	}
+	body, _ := json.MarshalIndent(map[string]any{"traditions": entries}, "", "  ")
+	return rpcResponse{Result: textContent(string(body))}
+}
+
+func verseToolResult(v schema.Verse) rpcResponse {
+	body, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return rpcResponse{Error: &rpcError{Code: codeInternalError, Message: err.Error()}}
+	}
+	return rpcResponse{Result: textContent(string(body))}
+}
+
+func versesToolResult(vs []schema.Verse) rpcResponse {
+	body, err := json.MarshalIndent(map[string]any{"verses": vs, "count": len(vs)}, "", "  ")
+	if err != nil {
+		return rpcResponse{Error: &rpcError{Code: codeInternalError, Message: err.Error()}}
+	}
+	return rpcResponse{Result: textContent(string(body))}
+}
+
+// errorToolResult returns an MCP tool error using the result-with-isError
+// convention: tool-level failures land as a tool result with isError=true,
+// not as a JSON-RPC error. This matches how MCP clients distinguish "the
+// transport failed" from "the tool ran and reported a problem".
+func errorToolResult(err error) rpcResponse {
+	return rpcResponse{Result: map[string]any{
+		"content": []map[string]any{{"type": "text", "text": "error: " + err.Error()}},
+		"isError": true,
+	}}
+}
+
+func textContent(s string) map[string]any {
+	return map[string]any{
+		"content": []map[string]any{{"type": "text", "text": s}},
+	}
+}
+

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -1,0 +1,293 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MiaoDX/verse-driven/internal/packs"
+)
+
+// roundTrip drives a Server end-to-end: writes the supplied request lines
+// to the server's stdin and returns each parsed response in order.
+func roundTrip(t *testing.T, requests ...any) []map[string]any {
+	t.Helper()
+	srv := New(packs.All())
+	var in bytes.Buffer
+	enc := json.NewEncoder(&in)
+	enc.SetEscapeHTML(false)
+	for _, r := range requests {
+		if err := enc.Encode(r); err != nil {
+			t.Fatalf("encode req: %v", err)
+		}
+	}
+	var out bytes.Buffer
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := srv.Serve(ctx, &in, &out); err != nil && err != io.EOF {
+		t.Fatalf("Serve: %v", err)
+	}
+	var responses []map[string]any
+	for _, line := range strings.Split(strings.TrimRight(out.String(), "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		var m map[string]any
+		if err := json.Unmarshal([]byte(line), &m); err != nil {
+			t.Fatalf("parse response %q: %v", line, err)
+		}
+		responses = append(responses, m)
+	}
+	return responses
+}
+
+func TestInitializeReturnsServerInfo(t *testing.T) {
+	resp := roundTrip(t, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "initialize",
+		"params":  map[string]any{},
+	})
+	if len(resp) != 1 {
+		t.Fatalf("got %d responses, want 1", len(resp))
+	}
+	r := resp[0]
+	if r["jsonrpc"] != "2.0" {
+		t.Errorf("jsonrpc = %v", r["jsonrpc"])
+	}
+	result, ok := r["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("result missing or wrong type: %v", r["result"])
+	}
+	if result["protocolVersion"] == "" || result["protocolVersion"] == nil {
+		t.Errorf("protocolVersion missing")
+	}
+	srvInfo := result["serverInfo"].(map[string]any)
+	if srvInfo["name"] != ServerName {
+		t.Errorf("serverInfo.name = %v, want %s", srvInfo["name"], ServerName)
+	}
+}
+
+func TestNotificationsHaveNoResponse(t *testing.T) {
+	// notifications/initialized has no `id` → no response.
+	resp := roundTrip(t, map[string]any{
+		"jsonrpc": "2.0",
+		"method":  "notifications/initialized",
+	})
+	if len(resp) != 0 {
+		t.Errorf("notification produced %d responses, want 0: %v", len(resp), resp)
+	}
+}
+
+func TestToolsListExposesAllFour(t *testing.T) {
+	resp := roundTrip(t, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      2,
+		"method":  "tools/list",
+	})
+	if len(resp) != 1 {
+		t.Fatalf("got %d responses, want 1", len(resp))
+	}
+	result := resp[0]["result"].(map[string]any)
+	tools, ok := result["tools"].([]any)
+	if !ok {
+		t.Fatalf("tools not a list: %v", result["tools"])
+	}
+	want := map[string]bool{"lookup": false, "search": false, "random": false, "list_traditions": false}
+	for _, t0 := range tools {
+		tm := t0.(map[string]any)
+		want[tm["name"].(string)] = true
+	}
+	for name, present := range want {
+		if !present {
+			t.Errorf("tool %q missing", name)
+		}
+	}
+}
+
+func TestToolsCallLookup(t *testing.T) {
+	resp := roundTrip(t, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      3,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name":      "lookup",
+			"arguments": map[string]any{"ref": "John 3:16"},
+		},
+	})
+	r := resp[0]
+	if e, ok := r["error"]; ok && e != nil {
+		t.Fatalf("got JSON-RPC error: %v", e)
+	}
+	result := r["result"].(map[string]any)
+	if result["isError"] == true {
+		t.Fatalf("tool reported isError=true: %v", result)
+	}
+	content := result["content"].([]any)
+	if len(content) == 0 {
+		t.Fatal("content empty")
+	}
+	text := content[0].(map[string]any)["text"].(string)
+	var v map[string]any
+	if err := json.Unmarshal([]byte(text), &v); err != nil {
+		t.Fatalf("verse text not JSON: %v\n%s", err, text)
+	}
+	if v["id"] != "bible.kjv.john.3.16" {
+		t.Errorf("verse id = %v", v["id"])
+	}
+	if v["checksum_sha256"] == nil {
+		t.Error("checksum missing")
+	}
+	if v["source"] == nil {
+		t.Error("source missing")
+	}
+}
+
+func TestToolsCallLookupErrorIsToolError(t *testing.T) {
+	resp := roundTrip(t, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      4,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name":      "lookup",
+			"arguments": map[string]any{"ref": "John 99:99"},
+		},
+	})
+	r := resp[0]
+	if e, ok := r["error"]; ok && e != nil {
+		t.Fatalf("expected tool-level error, got JSON-RPC error: %v", e)
+	}
+	result := r["result"].(map[string]any)
+	if result["isError"] != true {
+		t.Errorf("isError not set: %v", result)
+	}
+}
+
+func TestToolsCallSearch(t *testing.T) {
+	resp := roundTrip(t, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      5,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name":      "search",
+			"arguments": map[string]any{"query": "loved the world", "tradition": "bible", "limit": 3},
+		},
+	})
+	result := resp[0]["result"].(map[string]any)
+	text := result["content"].([]any)[0].(map[string]any)["text"].(string)
+	var body map[string]any
+	if err := json.Unmarshal([]byte(text), &body); err != nil {
+		t.Fatalf("search payload not JSON: %v\n%s", err, text)
+	}
+	if body["count"].(float64) < 1 {
+		t.Errorf("expected ≥1 match, got %v", body["count"])
+	}
+}
+
+func TestToolsCallRandomDao(t *testing.T) {
+	resp := roundTrip(t, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      6,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name":      "random",
+			"arguments": map[string]any{"tradition": "dao"},
+		},
+	})
+	result := resp[0]["result"].(map[string]any)
+	text := result["content"].([]any)[0].(map[string]any)["text"].(string)
+	var v map[string]any
+	if err := json.Unmarshal([]byte(text), &v); err != nil {
+		t.Fatalf("random payload not JSON: %v\n%s", err, text)
+	}
+	if v["tradition"] != "dao" {
+		t.Errorf("tradition filter ignored: %v", v["tradition"])
+	}
+}
+
+func TestToolsCallListTraditions(t *testing.T) {
+	resp := roundTrip(t, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      7,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name":      "list_traditions",
+			"arguments": map[string]any{},
+		},
+	})
+	result := resp[0]["result"].(map[string]any)
+	text := result["content"].([]any)[0].(map[string]any)["text"].(string)
+	var body map[string]any
+	if err := json.Unmarshal([]byte(text), &body); err != nil {
+		t.Fatalf("list_traditions payload not JSON: %v", err)
+	}
+	traditions := body["traditions"].([]any)
+	if len(traditions) < 3 {
+		t.Errorf("expected ≥3 traditions, got %d", len(traditions))
+	}
+}
+
+func TestUnknownMethodReturnsError(t *testing.T) {
+	resp := roundTrip(t, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      8,
+		"method":  "no/such/method",
+	})
+	r := resp[0]
+	e, ok := r["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected error object, got %v", r)
+	}
+	if e["code"].(float64) != codeMethodNotFound {
+		t.Errorf("error.code = %v, want %d", e["code"], codeMethodNotFound)
+	}
+}
+
+func TestParseErrorIsFlagged(t *testing.T) {
+	srv := New(packs.All())
+	in := bytes.NewBufferString("not json\n")
+	var out bytes.Buffer
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := srv.Serve(ctx, in, &out); err != nil {
+		t.Fatalf("Serve: %v", err)
+	}
+	var r map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out.String())), &r); err != nil {
+		t.Fatalf("parse output: %v\n%s", err, out.String())
+	}
+	e := r["error"].(map[string]any)
+	if e["code"].(float64) != codeParseError {
+		t.Errorf("code = %v, want %d", e["code"], codeParseError)
+	}
+}
+
+// TestLookupLatency is a light sanity check for the issue's "<5ms p50"
+// criterion. The bundled packs are in-memory and the lookup path is
+// O(1), so this should pass with margin on any modern CI runner.
+func TestLookupLatency(t *testing.T) {
+	srv := New(packs.All())
+	const trials = 200
+	durations := make([]time.Duration, 0, trials)
+	for i := 0; i < trials; i++ {
+		t0 := time.Now()
+		if _, err := srv.lookupByRef("John 3:16"); err != nil {
+			t.Fatalf("lookup err: %v", err)
+		}
+		durations = append(durations, time.Since(t0))
+	}
+	// crude p50: sort ascending, take middle.
+	for i := 1; i < len(durations); i++ {
+		for j := i; j > 0 && durations[j-1] > durations[j]; j-- {
+			durations[j-1], durations[j] = durations[j], durations[j-1]
+		}
+	}
+	p50 := durations[trials/2]
+	if p50 > 5*time.Millisecond {
+		t.Errorf("p50 lookup latency %v exceeds 5ms budget", p50)
+	}
+}

--- a/internal/packs/lookup.go
+++ b/internal/packs/lookup.go
@@ -1,0 +1,76 @@
+package packs
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/MiaoDX/verse-driven/internal/resolver"
+	"github.com/MiaoDX/verse-driven/internal/schema"
+)
+
+// ErrNotBundled signals the requested reference resolved to a tradition
+// that is shipped api-only in this build (heart-sutra, quran). Callers
+// can distinguish this from a hard "id not in pack" miss with errors.Is.
+var ErrNotBundled = errors.New("packs: verse not bundled in this build")
+
+// LookupReference maps a parsed resolver.Reference to a pack verse id and
+// returns the matching verse. Used by both the CLI and the MCP server so
+// the two interfaces share one mapping definition.
+func LookupReference(r resolver.Reference) (schema.Verse, error) {
+	id, err := ReferenceID(r)
+	if err != nil {
+		return schema.Verse{}, err
+	}
+	v, ok := All().Lookup(id)
+	if !ok {
+		if r.Tradition == resolver.TraditionSutra || r.Tradition == resolver.TraditionQuran {
+			return schema.Verse{}, fmt.Errorf("%w: %s", ErrNotBundled, r.Tradition)
+		}
+		return schema.Verse{}, fmt.Errorf("verse not found: %s", id)
+	}
+	return v, nil
+}
+
+// ReferenceID renders a resolver.Reference as the dotted lowercase pack
+// id (`<tradition>.<work>.<book?>.<chapter>.<verse>`). For traditions
+// where the resolver doesn't carry a verse number (e.g. dao "chapter 11",
+// heart sutra), VerseStart defaults to 1.
+func ReferenceID(r resolver.Reference) (string, error) {
+	verse := r.VerseStart
+	switch r.Tradition {
+	case resolver.TraditionBible:
+		if r.Book == "" {
+			return "", fmt.Errorf("bible reference missing book")
+		}
+		if r.Chapter < 1 || verse < 1 {
+			return "", fmt.Errorf("bible reference must include chapter and verse")
+		}
+		return fmt.Sprintf("bible.kjv.%s.%d.%d", bookSlug(r.Book), r.Chapter, verse), nil
+	case resolver.TraditionDao:
+		if r.Chapter < 1 {
+			return "", fmt.Errorf("dao reference missing chapter")
+		}
+		if verse < 1 {
+			verse = 1
+		}
+		return fmt.Sprintf("dao.daodejing.%d.%d", r.Chapter, verse), nil
+	case resolver.TraditionSutra:
+		if verse < 1 {
+			verse = 1
+		}
+		return fmt.Sprintf("sutra.heart-sutra.%d", verse), nil
+	case resolver.TraditionQuran:
+		if r.Chapter < 1 || verse < 1 {
+			return "", fmt.Errorf("quran reference must include surah and verse")
+		}
+		return fmt.Sprintf("quran.quran.%d.%d", r.Chapter, verse), nil
+	}
+	return "", fmt.Errorf("unsupported tradition: %s", r.Tradition)
+}
+
+func bookSlug(book string) string {
+	out := strings.ToLower(strings.TrimSpace(book))
+	out = strings.Join(strings.Fields(out), "-")
+	return out
+}

--- a/internal/packs/lookup_test.go
+++ b/internal/packs/lookup_test.go
@@ -1,0 +1,130 @@
+package packs
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/MiaoDX/verse-driven/internal/resolver"
+)
+
+func TestReferenceID(t *testing.T) {
+	cases := []struct {
+		name string
+		ref  resolver.Reference
+		want string
+	}{
+		{
+			name: "single-word book",
+			ref:  resolver.Reference{Tradition: "bible", Work: "KJV", Book: "John", Chapter: 3, VerseStart: 16},
+			want: "bible.kjv.john.3.16",
+		},
+		{
+			name: "numbered book stays numbered in slug",
+			ref:  resolver.Reference{Tradition: "bible", Work: "KJV", Book: "1 John", Chapter: 4, VerseStart: 8},
+			want: "bible.kjv.1-john.4.8",
+		},
+		{
+			name: "multi-word book becomes hyphen slug",
+			ref:  resolver.Reference{Tradition: "bible", Work: "KJV", Book: "Song of Solomon", Chapter: 1, VerseStart: 1},
+			want: "bible.kjv.song-of-solomon.1.1",
+		},
+		{
+			name: "dao defaults verse to 1 when omitted",
+			ref:  resolver.Reference{Tradition: "dao", Work: "daodejing", Chapter: 11},
+			want: "dao.daodejing.11.1",
+		},
+		{
+			name: "sutra uses single-segment id",
+			ref:  resolver.Reference{Tradition: "sutra", Work: "heart-sutra"},
+			want: "sutra.heart-sutra.1",
+		},
+		{
+			name: "quran follows surah:verse",
+			ref:  resolver.Reference{Tradition: "quran", Work: "quran", Chapter: 2, VerseStart: 255},
+			want: "quran.quran.2.255",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := ReferenceID(c.ref)
+			if err != nil {
+				t.Fatalf("ReferenceID(%v) err: %v", c.ref, err)
+			}
+			if got != c.want {
+				t.Errorf("ReferenceID = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestReferenceIDErrors(t *testing.T) {
+	cases := []resolver.Reference{
+		{Tradition: "bible", Work: "KJV", Chapter: 3, VerseStart: 16}, // missing book
+		{Tradition: "bible", Work: "KJV", Book: "John", VerseStart: 16}, // missing chapter
+		{Tradition: "dao", Work: "daodejing"},                          // missing chapter
+		{Tradition: "quran", Work: "quran", VerseStart: 1},             // missing surah
+		{Tradition: "unknown"},
+	}
+	for i, ref := range cases {
+		if _, err := ReferenceID(ref); err == nil {
+			t.Errorf("case %d: ReferenceID(%+v) returned no error", i, ref)
+		}
+	}
+}
+
+func TestLookupReferenceBibleFound(t *testing.T) {
+	v, err := LookupReference(resolver.Reference{
+		Tradition:  "bible",
+		Work:       "KJV",
+		Book:       "John",
+		Chapter:    3,
+		VerseStart: 16,
+	})
+	if err != nil {
+		t.Fatalf("LookupReference err: %v", err)
+	}
+	if v.ID != "bible.kjv.john.3.16" {
+		t.Errorf("got id %q", v.ID)
+	}
+	if v.Tradition != "bible" {
+		t.Errorf("got tradition %q", v.Tradition)
+	}
+}
+
+func TestLookupReferenceDaoFound(t *testing.T) {
+	v, err := LookupReference(resolver.Reference{
+		Tradition: "dao",
+		Work:      "daodejing",
+		Chapter:   11,
+	})
+	if err != nil {
+		t.Fatalf("LookupReference err: %v", err)
+	}
+	if v.ID != "dao.daodejing.11.1" {
+		t.Errorf("got id %q", v.ID)
+	}
+}
+
+func TestLookupReferenceSutraNotBundled(t *testing.T) {
+	_, err := LookupReference(resolver.Reference{Tradition: "sutra", Work: "heart-sutra"})
+	if !errors.Is(err, ErrNotBundled) {
+		t.Errorf("got %v, want ErrNotBundled", err)
+	}
+}
+
+func TestLookupReferenceQuranNotBundled(t *testing.T) {
+	_, err := LookupReference(resolver.Reference{Tradition: "quran", Work: "quran", Chapter: 2, VerseStart: 255})
+	if !errors.Is(err, ErrNotBundled) {
+		t.Errorf("got %v, want ErrNotBundled", err)
+	}
+}
+
+func TestLookupReferenceMissBibleVerse(t *testing.T) {
+	_, err := LookupReference(resolver.Reference{Tradition: "bible", Work: "KJV", Book: "John", Chapter: 99, VerseStart: 99})
+	if err == nil {
+		t.Fatal("expected error for missing verse, got nil")
+	}
+	if errors.Is(err, ErrNotBundled) {
+		t.Errorf("missing-verse error wrongly classified as ErrNotBundled: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #4.

Wires the full v0.1 binary surface. One executable now exposes
`serve`, `lookup`, `lookup-from-prompt`, `recap`, and `init`, with a
stdio MCP server that publishes four tools.

## What's in this PR

- `internal/mcp/server.go` — minimal JSON-RPC 2.0 stdio MCP server
  (NDJSON framing). Implements `initialize`, `tools/list`, `tools/call`,
  `ping`, `shutdown`, and the `notifications/initialized` notification.
  Tool-level failures are returned as `result-with-isError` per MCP
  convention; transport-level failures become JSON-RPC error objects.
  Zero non-stdlib dependencies — the surface is small enough (3 methods,
  4 tools, no resources/prompts) that pulling in an MCP SDK would
  double the project's dependency footprint for very little gain.
- `internal/cli/{cli,lookup,recap,init}.go` — subcommand handlers. The
  flag parser tolerates flags placed after positional args
  (`lookup "John 3:16" --format=json`) per the issue spec. JSON is the
  default `lookup` output.
- `lookup-from-prompt` accepts both Claude (`/bible John 3:16`) and
  Codex (`[[bible:John 3:16]]`) marker styles. It reads either a raw
  prompt or a JSON object with a `prompt`/`user_prompt` field on stdin
  (the latter is the form Claude Code / Codex hooks send) and emits an
  `additionalContext` envelope on stdout suitable for both
  `UserPromptExpansion` and `UserPromptSubmit`. With no marker it
  exits 0 silently so hooks add nothing to the prompt. Trailing user
  prompt text after the reference is handled by progressively trimming
  tokens from the right until the resolver accepts what remains.
- `recap` — Mode B terminal print. `--tradition=` filters,
  `--first-letter` masks all-but-first character of each word/Han
  glyph for memory mode, `--seed=N` makes selection deterministic.
  Recap output goes to stdout only; the contract that it never enters
  a `model_call` input is enforced by where the agents invoke it
  (Claude Stop hook, Codex `cdx` shell wrapper) — both land in #5/#6.
- `init --target={claude-code,codex} [--recap=on|off] [--uninstall]
  [--dry-run]` — splices a marker-fenced snippet into
  `~/.claude/settings.json` or `~/.codex/config.toml`. Idempotent
  (a second run reports "already up to date"); `--uninstall` strips
  the block and collapses the surrounding blank line; user content
  outside the markers is preserved. The Claude snippet matches
  `plan.md` §5.1; the Codex snippet matches §5.2.
- `internal/injector/envelope.go` — renders the §6.3 reflection
  envelope wrapping verse text in `<scripture_card>` tags with the
  "do not preach / quote verbatim" framing. `DisplayRef` formats the
  verse's reference for human display, switching by tradition.
- `internal/packs/lookup.go` — shared `LookupReference(r resolver.Reference)`
  and `ReferenceID(r)` helpers, used by both `internal/cli` and
  `internal/mcp` so the resolver→pack-id mapping has a single
  authoritative implementation. Returns `packs.ErrNotBundled` when the
  reference resolves to a tradition shipped api-only in this build
  (heart-sutra, quran), distinct from a hard "id miss" error.

## Acceptance-criteria mapping

- [x] `scripture-mcp serve` launches a stdio MCP server
- [x] MCP tools: `lookup`, `search`, `random`, `list_traditions` —
      all return verses with `checksum_sha256` and `source`
- [x] Speaks the snippet from `plan.md` §5.1 (Claude Code) and §5.2
      (Codex) — `init` writes those snippets verbatim
- [x] `scripture-mcp lookup "<ref>" --format=json` → JSON Verse on
      stdout (default; `--format=text` for terminal-pretty)
- [x] `scripture-mcp lookup-from-prompt` reads stdin, emits
      `additionalContext` JSON suitable for both Claude
      `UserPromptExpansion` and Codex `UserPromptSubmit`
- [x] `scripture-mcp recap [--tradition=<t>] [--terminal]` prints
      pretty terminal output, exit 0
- [x] `scripture-mcp recap --first-letter` prints first-letter pattern
- [x] `scripture-mcp init --target={claude-code,codex}` merges config
      snippet without overwriting; idempotent; supports `--uninstall`
      and `--dry-run`
- [x] p50 latency for MCP `lookup` < 5 ms — verified by
      `TestLookupLatency` (200 trials over the in-memory registry)

## Tests

- `internal/mcp/server_test.go` — `initialize`, notifications-have-no-
  reply, `tools/list` exposes all four, `tools/call` for each tool
  including the missing-verse → tool-error path, parse-error framing,
  unknown-method → method-not-found, and the p50 latency check.
- `internal/cli/lookup_test.go` — JSON default, JSON/text formats,
  ambiguous → exit 3, unrecognized → exit 1, sutra → "not bundled"
  message, plus marker-scan tests for slash and inline forms (with
  trailing prompt text), JSON input form, and silent-on-no-marker.
- `internal/cli/recap_test.go` — deterministic with seed, tradition
  filter, first-letter mask (ASCII + Han), unknown-tradition exit.
- `internal/cli/init_test.go` — file creation, recap-on/off variant,
  idempotent rerun, user-content preservation, uninstall, codex TOML
  output, missing-target → exit 2, dry-run.
- `internal/injector/envelope_test.go` — envelope wrapper structure
  and per-tradition `DisplayRef` cases.
- `internal/packs/lookup_test.go` — `ReferenceID` mapping incl.
  multi-word and numbered books, error cases, `LookupReference`
  happy/api-only/miss paths.

## Verification

- `make all` (lint + verify-packs + test + build) clean
- Smoke test: `./bin/scripture-mcp lookup "John 3:16" --format=json`
  resolves, returns canonical verse with checksum
  `8473c0b1c7664945528317faf77351258eb79f8b11ba821ef76d7e916cde711a`
- Smoke test: piping three JSON-RPC requests
  (`initialize` / `tools/list` / `tools/call lookup John 3:16`) into
  `scripture-mcp serve` returns protocolVersion `2024-11-05`, the
  full tool list, and the verse with matching checksum

---
_Generated by [Claude Code](https://claude.ai/code/session_012GFeoo4qaEGPRmp27htk5F)_