### PR TITLE
fix: #5 — feat(claude): Claude Code adapter (Mode A + Mode B + skill)

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,27 @@ scripture-mcp init --target=codex
 `init` merges config snippets into your existing `settings.json` /
 `config.toml` — it does not overwrite your config.
 
+### Claude Code adapter assets
+
+In addition to the `settings.json` snippet that `init --target=claude-code`
+installs, the Claude adapter ships two static assets you symlink (or copy)
+into your Claude config:
+
+```bash
+# Output style — turns on the <scripture_card> reading mode.
+ln -s "$PWD/adapters/claude-code/output-styles/scripture-recap.md" \
+      ~/.claude/output-styles/scripture-recap.md
+
+# Manual fallback skill — preview a verse without typing the slash marker.
+mkdir -p ~/.claude/skills/verse-inject
+ln -s "$PWD/adapters/claude-code/skills/verse-inject/SKILL.md" \
+      ~/.claude/skills/verse-inject/SKILL.md
+```
+
+Both files are deliberately tiny and contain **no scripture text** —
+verses are fetched from the bundled MCP server at lookup time. The skill
+sets `disable-model-invocation: true` so the model never auto-triggers it.
+
 ---
 
 ## Roadmap

--- a/adapters/adapters.go
+++ b/adapters/adapters.go
@@ -1,0 +1,22 @@
+// Package adapters bundles the per-agent assets shipped alongside the
+// scripture-mcp binary — output styles, skills, and any wrapper scripts
+// the agents need to be wired into. The files themselves remain on disk
+// (so users can read and copy them) and are also embedded here so unit
+// tests can assert structural properties without duplicating content.
+package adapters
+
+import "embed"
+
+// ClaudeCodeFS exposes adapters/claude-code/** for tests and for any
+// future installer that wants to materialize the assets into a user's
+// agent config directory.
+//
+//go:embed claude-code/output-styles/scripture-recap.md
+//go:embed claude-code/skills/verse-inject/SKILL.md
+var ClaudeCodeFS embed.FS
+
+// ClaudeOutputStylePath is the in-FS path of the output style.
+const ClaudeOutputStylePath = "claude-code/output-styles/scripture-recap.md"
+
+// ClaudeVerseInjectSkillPath is the in-FS path of the verse-inject skill.
+const ClaudeVerseInjectSkillPath = "claude-code/skills/verse-inject/SKILL.md"

--- a/adapters/adapters_test.go
+++ b/adapters/adapters_test.go
@@ -1,0 +1,78 @@
+package adapters
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/MiaoDX/verse-driven/internal/packs"
+)
+
+func TestClaudeOutputStyleHasRequiredFrontmatter(t *testing.T) {
+	body := readEmbedded(t, ClaudeOutputStylePath)
+	for _, want := range []string{
+		"name: Scripture-Aware Coding",
+		"keep-coding-instructions: true",
+		"<scripture_card>",
+		"do not preach",
+		"behave exactly like default Claude Code",
+	} {
+		if !strings.Contains(strings.ToLower(body), strings.ToLower(want)) {
+			t.Errorf("output style missing %q", want)
+		}
+	}
+	// Style file is style-only — must not name a specific tradition.
+	for _, leak := range []string{"bible", "kjv", "dao", "道德", "sutra", "心经", "quran"} {
+		if strings.Contains(strings.ToLower(body), leak) {
+			t.Errorf("output style names tradition %q (must be tradition-agnostic)", leak)
+		}
+	}
+}
+
+func TestVerseInjectSkillIsManualOnlyAndShortAndScriptureFree(t *testing.T) {
+	body := readEmbedded(t, ClaudeVerseInjectSkillPath)
+
+	// < 60 lines (issue #5 acceptance criterion).
+	if got := strings.Count(body, "\n"); got >= 60 {
+		t.Errorf("SKILL.md has %d lines (want < 60)", got)
+	}
+
+	// Required frontmatter fields.
+	for _, want := range []string{
+		"name: verse-inject",
+		"disable-model-invocation: true",
+		"mcp__scripture__lookup",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("SKILL.md missing %q", want)
+		}
+	}
+
+	// Skill body must contain no scripture text. Spot-check against
+	// every bundled verse: any verse text appearing as a substring of
+	// the skill body would mean we leaked scripture content.
+	r := packs.All()
+	for _, name := range r.Names() {
+		p := r.Pack(name)
+		if p.Meta.InclusionMode != "" && p.Meta.InclusionMode != "bundled" {
+			continue
+		}
+		for _, v := range p.Verses() {
+			if len(v.Text) < 12 {
+				continue // too short to be a meaningful match
+			}
+			if strings.Contains(body, v.Text) {
+				t.Errorf("SKILL.md contains scripture text from %s", v.ID)
+				return
+			}
+		}
+	}
+}
+
+func readEmbedded(t *testing.T, path string) string {
+	t.Helper()
+	b, err := ClaudeCodeFS.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
+}

--- a/adapters/claude-code/output-styles/scripture-recap.md
+++ b/adapters/claude-code/output-styles/scripture-recap.md
@@ -1,0 +1,14 @@
+---
+name: Scripture-Aware Coding
+description: Coding style that respects optional one-turn scripture frames.
+keep-coding-instructions: true
+---
+
+If the current turn includes a developer context block marked
+<scripture_card>, treat it as an optional reflective frame for THIS turn only.
+
+Rules:
+1. Do not change coding priorities, testing, or verification because of it.
+2. If a scripture is quoted in the card, quote it verbatim if you mention it.
+3. Do not preach, do not extend the metaphor.
+4. If no <scripture_card> is present, behave exactly like default Claude Code.

--- a/adapters/claude-code/skills/verse-inject/SKILL.md
+++ b/adapters/claude-code/skills/verse-inject/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: verse-inject
+description: Manually preview and one-turn-inject a scripture passage as a reflective frame. Invoke explicitly; never auto-trigger.
+disable-model-invocation: true
+allowed-tools:
+  - mcp__scripture__lookup
+  - mcp__scripture__list_traditions
+---
+
+# verse-inject
+
+A manual fallback for the `/bible|/dao|/sutra|/quran` slash-marker flow.
+Use this skill when the user wants to preview a verse and explicitly choose
+whether to inject it as a one-turn reflective frame.
+
+This skill is **manually invoked only**. The frontmatter sets
+`disable-model-invocation: true` so the model never auto-triggers it.
+
+## Inputs
+
+The user supplies a free-form reference, e.g. `John 3:16`, `约翰福音 3:16`,
+`道德经 11`, `Quran 2:255`, or just `心经`. If no reference is supplied,
+ask which tradition and reference they want.
+
+## Steps
+
+1. Call `mcp__scripture__lookup` with the user's reference.
+2. Render a preview to the user containing exactly three pieces of
+   metadata returned by the MCP tool: `display_ref`, `source.attribution`,
+   and `checksum_sha256`. Quote the verse `text` verbatim **once**, in
+   the preview only. Do not paraphrase, summarize, or extend the metaphor.
+3. Ask the user explicitly: "Inject this as a one-turn reflective frame
+   for your next coding request? (yes / no)".
+4. If the user declines, stop. Do not retain the verse in your reply
+   beyond the preview.
+5. If the user confirms, instruct them to send their next coding
+   request prefixed with the slash marker
+   (e.g. `/bible John 3:16 Refactor X.`) so the
+   `UserPromptExpansion` hook performs the one-turn injection.
+   Do not try to inject the envelope yourself: the hook is the only
+   path that produces the temporary, turn-bounded developer-context
+   block this project guarantees.
+
+## Invariants
+
+- This skill body contains no scripture text. All verse content comes
+  from the MCP `lookup` tool at runtime.
+- Preview the verse at most once per invocation.
+- Never re-quote the verse in subsequent turns of the same session.
+- Never alter coding priorities, testing rigor, or safety behavior in
+  response to the verse content.
+
+## Errors
+
+If `lookup` returns "not bundled" or "ambiguous", surface the error
+verbatim and ask the user to disambiguate. Do not guess.

--- a/internal/injector/envelope.go
+++ b/internal/injector/envelope.go
@@ -32,6 +32,14 @@ func Envelope(v schema.Verse) string {
 		b.WriteString(", ")
 		b.WriteString(v.Source.Attribution)
 	}
+	if v.ChecksumSHA256 != "" {
+		// Surface the integrity checksum in the preview so the user can
+		// verify the verse came from the bundled pack and was not
+		// rewritten in transit. The model is instructed not to act on
+		// this beyond reproducing it verbatim if asked.
+		b.WriteString("\nchecksum: sha256:")
+		b.WriteString(v.ChecksumSHA256)
+	}
 	b.WriteString("\n</scripture_card>\n")
 	return b.String()
 }

--- a/internal/injector/envelope_test.go
+++ b/internal/injector/envelope_test.go
@@ -28,6 +28,7 @@ func TestEnvelopeWrapsScriptureCard(t *testing.T) {
 		"TXT",
 		"John 3:16",
 		"KJV",
+		"checksum: sha256:" + strings.Repeat("0", 64),
 		"</scripture_card>",
 	} {
 		if !strings.Contains(out, want) {


### PR DESCRIPTION
Closes #5.

Ships the two static assets the Claude Code adapter needs on top of the
`settings.json` snippet that `scripture-mcp init --target=claude-code`
already installs (landed in #4 / PR #14).

## What's in this PR

- **`adapters/claude-code/output-styles/scripture-recap.md`** — style
  only, matches `plan.md` §5.1 verbatim. Sets
  `keep-coding-instructions: true` and instructs the model to treat
  `<scripture_card>` as a one-turn reflective frame. Contains **no
  scripture text** and names **no specific tradition**, per the
  issue's requirement.
- **`adapters/claude-code/skills/verse-inject/SKILL.md`** — the manual
  fallback skill for the slash-marker flow. Sets
  `disable-model-invocation: true` so the model never auto-triggers
  it. Body is **56 lines** (< 60 per the issue), contains no scripture
  text, and instructs the agent to call `mcp__scripture__lookup` for
  every verse fetch — the preview shows `display_ref`, attribution,
  and `checksum_sha256`, then the user explicitly confirms before any
  injection happens.
- **`adapters/adapters.go`** — a tiny package that embeds the two
  static files via `embed.FS`. The package exists primarily so the
  test suite can assert structural properties of the assets without
  duplicating their content; the `Claude*Path` constants also
  document the canonical in-FS paths for the eventual installer in
  #7.
- **`internal/injector/envelope.go`** — the §6.3 envelope now carries
  a `checksum: sha256:<hex>` line so the Mode A preview surfaces all
  three integrity fields the issue requires: verse text + source +
  checksum. The model is instructed (in the envelope's leading
  paragraph) not to act on the checksum beyond reproducing it
  verbatim if asked.
- **`README.md`** — documents the symlink/copy install path for the
  two adapter assets. They're deliberately **not** auto-materialized
  by `init`: init's only acceptance criterion for #5 is recap on/off
  toggling, which #4 already met, and extending init to write files
  outside its existing splice surface would expand scope.

## Acceptance-criteria mapping

**Mode A — UserPromptExpansion hook:**
- [x] `/bible John 3:16` shows a preview card with verse text + source + checksum (envelope now carries the checksum line)
- [x] User must explicitly confirm before the model sees the verse (UserPromptExpansion shows the expanded prompt to the user before submission; the user hits Enter to confirm)
- [x] On confirm, the next coding request is wrapped with the temporary envelope from `plan.md` §6.3
- [x] `keep-coding-instructions: true` set on the active output style
- [x] Works for all 4 marker traditions: `bible`, `dao`, `sutra`, `quran` (covered by #4's `lookup-from-prompt` regex)
- [x] Hook exits silently if the prompt has no marker (covered by #4)

**Mode A — `verse-inject` skill:**
- [x] `adapters/claude-code/skills/verse-inject/SKILL.md` exists and is 56 lines (< 60)
- [x] `disable-model-invocation: true` in frontmatter
- [x] Skill body contains **no scripture text** — calls `mcp__scripture__lookup` via MCP (asserted by `TestVerseInjectSkillIsManualOnlyAndShortAndScriptureFree`, which substring-scans the body against every bundled verse > 12 bytes)
- [x] Manually invoking the skill triggers the same preview/confirm/inject flow (skill body steps 1–5)

**Mode B — output style + Stop hook:**
- [x] `adapters/claude-code/output-styles/scripture-recap.md` defines style only — no scripture text or specific traditions (asserted by `TestClaudeOutputStyleHasRequiredFrontmatter`)
- [x] Stop hook calls `scripture-mcp recap --terminal` (covered by #4 via `init --target=claude-code --recap=on`)
- [x] Mode B toggleable via `scripture-mcp init --target=claude-code --recap=on|off` (covered by #4)
- [x] Recap text does NOT appear in the next prompt's input — architectural property: Stop-hook stdout flows to the terminal, not into `model_call`. Rigorous end-to-end verification of this invariant is the explicit gate of #8 (`test(critical): injection lifecycle`); this issue treats it as a smoke-tested architectural guarantee.

## Tests

- `adapters/adapters_test.go` — embedded-asset frontmatter assertions,
  line-count check on SKILL.md, no-scripture-text scan against every
  bundled verse, no-tradition-leak check on the style file.
- `internal/injector/envelope_test.go` — added the
  `checksum: sha256:<hex>` line to the envelope assertion list.

## Verification

- `make build` clean
- `staticcheck ./...` clean
- `go test ./...` — green across all 7 packages
- `python3 scripts/verify_quotes.py` — 31,183 verses, 0 mismatches
- Smoke: `echo '/bible John 3:16 Refactor X.' | ./bin/scripture-mcp lookup-from-prompt` emits an `additionalContext` envelope containing the verse, the `John 3:16` display ref, the KJV attribution, and `checksum: sha256:8473c0b1c7664945528317faf77351258eb79f8b11ba821ef76d7e916cde711a`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GwZwT41Z5H6TBSoaKuFcBM)_