### PR TITLE
fix: #6 — feat(codex): Codex adapter (Mode A + Mode B + skill)

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,51 @@ Both files are deliberately tiny and contain **no scripture text** —
 verses are fetched from the bundled MCP server at lookup time. The skill
 sets `disable-model-invocation: true` so the model never auto-triggers it.
 
+### Codex adapter assets
+
+Codex Mode A is wired entirely through the `config.toml` snippet
+`init --target=codex` writes (the `UserPromptSubmit` hook calls
+`scripture-mcp lookup-from-prompt`, which recognizes the inline marker
+syntax `[[bible:John 3:16]]`).
+
+In addition, the adapter ships:
+
+```bash
+# Manual fallback skill — preview before sending the [[…]] marker.
+mkdir -p ~/.codex/skills/scripture-lookup/agents
+ln -s "$PWD/adapters/codex/skills/scripture-lookup/SKILL.md" \
+      ~/.codex/skills/scripture-lookup/SKILL.md
+ln -s "$PWD/adapters/codex/skills/scripture-lookup/agents/openai.yaml" \
+      ~/.codex/skills/scripture-lookup/agents/openai.yaml
+
+# Mode B recap wrapper — Codex has no Stop hook, so recap fires from
+# a thin shell wrapper that runs *outside* the Codex transcript.
+cp adapters/codex/wrapper/cdx ~/.local/bin/cdx
+chmod +x ~/.local/bin/cdx
+# Then run `cdx ...` instead of `codex ...`.
+# A PowerShell counterpart lives at adapters/codex/wrapper/cdx.ps1.
+```
+
+The skill's `agents/openai.yaml` pins `allow_implicit_invocation: false`
+so the OpenAI/Codex model cannot auto-invoke `scripture-lookup` during a
+coding turn — it must be called by name. The skill body, like its Claude
+counterpart, contains **no scripture text**: verses are fetched from the
+bundled MCP server at lookup time.
+
+**Codex skill path note:** official Codex docs and OSS repos disagree on
+whether per-user skills live under `~/.codex/skills`, `$CODEX_HOME/skills`,
+or `~/.agents/skills`. The snippets above use `~/.codex/skills`, matching
+the same `~/.codex/config.toml` location `init --target=codex` writes to.
+If your Codex build expects a different path, symlink the skill there
+instead.
+
+**Honest limitation:** the recap fires because the wrapping shell stays
+alive after `codex` exits and runs `scripture-mcp recap --terminal`.
+Launching `codex` directly (without `cdx`) bypasses the recap entirely.
+This is a deliberate physical-isolation trade-off — see [`plan.md`](./plan.md)
+§5.2 — and means there is no way for the recap text to leak into a future
+Codex `model_call` input.
+
 ---
 
 ## Roadmap

--- a/adapters/adapters.go
+++ b/adapters/adapters.go
@@ -20,3 +20,24 @@ const ClaudeOutputStylePath = "claude-code/output-styles/scripture-recap.md"
 
 // ClaudeVerseInjectSkillPath is the in-FS path of the verse-inject skill.
 const ClaudeVerseInjectSkillPath = "claude-code/skills/verse-inject/SKILL.md"
+
+// CodexFS exposes adapters/codex/** for tests and the future installer.
+//
+//go:embed codex/skills/scripture-lookup/SKILL.md
+//go:embed codex/skills/scripture-lookup/agents/openai.yaml
+//go:embed codex/wrapper/cdx
+//go:embed codex/wrapper/cdx.ps1
+var CodexFS embed.FS
+
+// CodexScriptureLookupSkillPath is the in-FS path of the Codex skill.
+const CodexScriptureLookupSkillPath = "codex/skills/scripture-lookup/SKILL.md"
+
+// CodexOpenAIAgentPath is the in-FS path of the per-agent skill manifest
+// that pins allow_implicit_invocation: false for the OpenAI/Codex model.
+const CodexOpenAIAgentPath = "codex/skills/scripture-lookup/agents/openai.yaml"
+
+// CodexWrapperPOSIXPath is the in-FS path of the POSIX `cdx` wrapper.
+const CodexWrapperPOSIXPath = "codex/wrapper/cdx"
+
+// CodexWrapperPowerShellPath is the in-FS path of the PowerShell wrapper.
+const CodexWrapperPowerShellPath = "codex/wrapper/cdx.ps1"

--- a/adapters/adapters_test.go
+++ b/adapters/adapters_test.go
@@ -68,9 +68,115 @@ func TestVerseInjectSkillIsManualOnlyAndShortAndScriptureFree(t *testing.T) {
 	}
 }
 
+func TestCodexScriptureLookupSkillIsManualOnlyAndScriptureFree(t *testing.T) {
+	body := readCodexEmbedded(t, CodexScriptureLookupSkillPath)
+
+	// Required frontmatter / structural fields. Codex's per-agent
+	// allow_implicit_invocation pin lives in agents/openai.yaml; the
+	// SKILL.md only has to identify itself and reference the MCP tool.
+	for _, want := range []string{
+		"name: scripture-lookup",
+		"allow_implicit_invocation: false",
+		"mcp__scripture__lookup",
+		"[[bible:John 3:16]]",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("SKILL.md missing %q", want)
+		}
+	}
+
+	// Skill body must contain no scripture text. Spot-check against
+	// every bundled verse: any verse text appearing as a substring of
+	// the skill body would mean we leaked scripture content.
+	r := packs.All()
+	for _, name := range r.Names() {
+		p := r.Pack(name)
+		if p.Meta.InclusionMode != "" && p.Meta.InclusionMode != "bundled" {
+			continue
+		}
+		for _, v := range p.Verses() {
+			if len(v.Text) < 12 {
+				continue
+			}
+			if strings.Contains(body, v.Text) {
+				t.Errorf("Codex SKILL.md contains scripture text from %s", v.ID)
+				return
+			}
+		}
+	}
+}
+
+func TestCodexOpenAIAgentPinsImplicitInvocationOff(t *testing.T) {
+	body := readCodexEmbedded(t, CodexOpenAIAgentPath)
+	for _, want := range []string{
+		"name: scripture-lookup",
+		"allow_implicit_invocation: false",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("agents/openai.yaml missing %q", want)
+		}
+	}
+}
+
+func TestCodexPOSIXWrapperShape(t *testing.T) {
+	body := readCodexEmbedded(t, CodexWrapperPOSIXPath)
+	for _, want := range []string{
+		"#!/usr/bin/env bash",
+		"scripture-mcp",
+		"recap --terminal",
+		"exit_code=$?",
+		"exit $exit_code",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("cdx wrapper missing %q", want)
+		}
+	}
+	// recap must run regardless of codex's exit status. We assert this
+	// structurally by requiring the recap line to appear after the exit
+	// code is captured but before the wrapper exits with that code.
+	captureIdx := strings.Index(body, "exit_code=$?")
+	recapIdx := strings.Index(body, "recap --terminal")
+	finalExit := strings.LastIndex(body, "exit $exit_code")
+	if captureIdx < 0 || recapIdx < 0 || finalExit < 0 ||
+		!(captureIdx < recapIdx && recapIdx < finalExit) {
+		t.Errorf("cdx wrapper must capture exit code, then recap, then exit; got positions capture=%d recap=%d exit=%d",
+			captureIdx, recapIdx, finalExit)
+	}
+}
+
+func TestCodexPowerShellWrapperShape(t *testing.T) {
+	body := readCodexEmbedded(t, CodexWrapperPowerShellPath)
+	for _, want := range []string{
+		"$LASTEXITCODE",
+		"recap --terminal",
+		"exit $exitCode",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("cdx.ps1 wrapper missing %q", want)
+		}
+	}
+	captureIdx := strings.Index(body, "$exitCode = $LASTEXITCODE")
+	recapIdx := strings.Index(body, "recap --terminal")
+	finalExit := strings.LastIndex(body, "exit $exitCode")
+	if captureIdx < 0 || recapIdx < 0 || finalExit < 0 ||
+		!(captureIdx < recapIdx && recapIdx < finalExit) {
+		t.Errorf("cdx.ps1 wrapper must capture exit code, then recap, then exit; got positions capture=%d recap=%d exit=%d",
+			captureIdx, recapIdx, finalExit)
+	}
+}
+
 func readEmbedded(t *testing.T, path string) string {
 	t.Helper()
 	b, err := ClaudeCodeFS.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
+}
+
+func readCodexEmbedded(t *testing.T, path string) string {
+	t.Helper()
+	b, err := CodexFS.ReadFile(path)
 	if err != nil {
 		t.Fatalf("read %s: %v", path, err)
 	}

--- a/adapters/codex/skills/scripture-lookup/SKILL.md
+++ b/adapters/codex/skills/scripture-lookup/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: scripture-lookup
+description: Manually preview and one-turn-inject a scripture passage as a reflective frame. Invoke explicitly via the [[tradition:ref]] marker or by name; never auto-trigger.
+allow_implicit_invocation: false
+allowed-tools:
+  - mcp__scripture__lookup
+  - mcp__scripture__list_traditions
+---
+
+# scripture-lookup
+
+A manual fallback for the inline `[[bible:John 3:16]]` marker flow used by
+the Codex `UserPromptSubmit` hook. Use this skill when the user wants to
+preview a verse and explicitly choose whether to inject it as a one-turn
+reflective frame.
+
+This skill is **manually invoked only**. The `agents/openai.yaml` companion
+file sets `allow_implicit_invocation: false` so the model never auto-triggers
+it during ordinary coding turns.
+
+## Inputs
+
+The user supplies a free-form reference, e.g. `John 3:16`, `约翰福音 3:16`,
+`道德经 11`, `Quran 2:255`, or just `心经`. If no reference is supplied,
+ask which tradition and reference they want.
+
+## Steps
+
+1. Call `mcp__scripture__lookup` with the user's reference.
+2. Render a preview to the user containing exactly three pieces of
+   metadata returned by the MCP tool: `display_ref`, `source.attribution`,
+   and `checksum_sha256`. Quote the verse `text` verbatim **once**, in
+   the preview only. Do not paraphrase, summarize, or extend the metaphor.
+3. Ask the user explicitly: "Inject this as a one-turn reflective frame
+   for your next coding request? (yes / no)".
+4. If the user declines, stop. Do not retain the verse in your reply
+   beyond the preview.
+5. If the user confirms, instruct them to send their next coding
+   request with the inline marker (e.g.
+   `[[bible:John 3:16]] Refactor X.`) so the `UserPromptSubmit` hook
+   performs the one-turn injection. Do not try to inject the envelope
+   yourself: the hook is the only path that produces the temporary,
+   turn-bounded developer-context block this project guarantees.
+
+## Invariants
+
+- This skill body contains no scripture text. All verse content comes
+  from the MCP `lookup` tool at runtime.
+- Preview the verse at most once per invocation.
+- Never re-quote the verse in subsequent turns of the same session.
+- Never alter coding priorities, testing rigor, or safety behavior in
+  response to the verse content.
+
+## Errors
+
+If `lookup` returns "not bundled" or "ambiguous", surface the error
+verbatim and ask the user to disambiguate. Do not guess.

--- a/adapters/codex/skills/scripture-lookup/agents/openai.yaml
+++ b/adapters/codex/skills/scripture-lookup/agents/openai.yaml
@@ -1,0 +1,6 @@
+# Codex per-agent skill manifest. Pinning allow_implicit_invocation: false
+# means OpenAI/Codex models cannot auto-invoke scripture-lookup during a
+# coding turn; the user must call the skill by name. This is the Codex-side
+# equivalent of Claude Code's `disable-model-invocation: true` frontmatter.
+name: scripture-lookup
+allow_implicit_invocation: false

--- a/adapters/codex/wrapper/cdx
+++ b/adapters/codex/wrapper/cdx
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# cdx — Codex shell wrapper that fires a Mode B scripture recap after the
+# Codex session ends. Codex has no equivalent of Claude Code's `Stop` hook,
+# so the recap runs in the wrapping shell process, physically outside any
+# Codex transcript or model_call input.
+#
+# Install: place this file on $PATH (or alias `cdx` to it) and run `cdx`
+# instead of `codex`. The wrapper preserves the exit code of the wrapped
+# `codex` invocation; recap fires on success and on non-zero exit.
+#
+# Limitation: launching `codex` directly bypasses this wrapper, so the
+# recap is opt-in by use of `cdx`.
+
+set -u
+
+CODEX_BIN="${CODEX_BIN:-codex}"
+SCRIPTURE_BIN="${SCRIPTURE_MCP_BIN:-scripture-mcp}"
+
+if ! command -v "$CODEX_BIN" >/dev/null 2>&1; then
+  echo "cdx: $CODEX_BIN not found on PATH" >&2
+  exit 127
+fi
+
+"$CODEX_BIN" "$@"
+exit_code=$?
+
+if command -v "$SCRIPTURE_BIN" >/dev/null 2>&1; then
+  "$SCRIPTURE_BIN" recap --terminal || true
+else
+  echo "cdx: $SCRIPTURE_BIN not found on PATH; skipping recap" >&2
+fi
+
+exit $exit_code

--- a/adapters/codex/wrapper/cdx.ps1
+++ b/adapters/codex/wrapper/cdx.ps1
@@ -1,0 +1,33 @@
+# cdx.ps1 — Windows PowerShell counterpart of the POSIX `cdx` wrapper.
+# Fires a Mode B scripture recap after the wrapped Codex session ends.
+# Codex has no equivalent of Claude Code's `Stop` hook, so the recap runs
+# in the wrapping PowerShell process, physically outside any Codex
+# transcript or model_call input.
+#
+# Install: place this file on $env:PATH (or alias `cdx` to it) and run
+# `cdx` instead of `codex`. The wrapper preserves the exit code of the
+# wrapped `codex` invocation; recap fires on success and on non-zero exit.
+#
+# Limitation: launching `codex` directly bypasses this wrapper, so the
+# recap is opt-in by use of `cdx`.
+
+$ErrorActionPreference = 'Continue'
+
+$codexBin = if ($env:CODEX_BIN) { $env:CODEX_BIN } else { 'codex' }
+$scriptureBin = if ($env:SCRIPTURE_MCP_BIN) { $env:SCRIPTURE_MCP_BIN } else { 'scripture-mcp' }
+
+if (-not (Get-Command $codexBin -ErrorAction SilentlyContinue)) {
+    Write-Error "cdx: $codexBin not found on PATH"
+    exit 127
+}
+
+& $codexBin @args
+$exitCode = $LASTEXITCODE
+
+if (Get-Command $scriptureBin -ErrorAction SilentlyContinue) {
+    & $scriptureBin recap --terminal
+} else {
+    Write-Error "cdx: $scriptureBin not found on PATH; skipping recap"
+}
+
+exit $exitCode

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -47,12 +48,32 @@ func runInit(args []string, s Streams) int {
 			renderClaudeSnippet(*recap == "on"), *uninstall, *dryRun, s)
 	case "codex":
 		path := filepath.Join(home, ".codex", "config.toml")
-		return manageSnippet(path, "# >>> verse-driven", "# <<< verse-driven",
+		code := manageSnippet(path, "# >>> verse-driven", "# <<< verse-driven",
 			renderCodexSnippet(*recap == "on"), *uninstall, *dryRun, s)
+		if code == 0 && !*dryRun && !*uninstall && *recap == "on" {
+			printCdxAliasHint(s.Out)
+		}
+		return code
 	default:
 		fmt.Fprintf(s.Err, "error: unknown target %q (want claude-code|codex)\n", *target)
 		return 2
 	}
+}
+
+// printCdxAliasHint emits the wrapper-setup instructions for Codex Mode B.
+// Codex has no Stop-equivalent hook, so the recap fires from a thin shell
+// wrapper that wraps the `codex` invocation; the user has to put the
+// wrapper on PATH (or alias `cdx` to it) themselves. We never modify the
+// user's shell rc files automatically.
+func printCdxAliasHint(out io.Writer) {
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "verse-driven: Codex Mode B recap requires the `cdx` shell wrapper.")
+	fmt.Fprintln(out, "  Wrapper source: adapters/codex/wrapper/cdx (POSIX) or cdx.ps1 (PowerShell).")
+	fmt.Fprintln(out, "  Install one of:")
+	fmt.Fprintln(out, "    cp adapters/codex/wrapper/cdx ~/.local/bin/cdx && chmod +x ~/.local/bin/cdx")
+	fmt.Fprintln(out, "    alias cdx='/path/to/adapters/codex/wrapper/cdx'   # add to ~/.bashrc or ~/.zshrc")
+	fmt.Fprintln(out, "  Then run `cdx ...` instead of `codex ...` to get a terminal recap on exit.")
+	fmt.Fprintln(out, "  Note: launching `codex` directly bypasses the recap.")
 }
 
 func homeDir(s Streams) (string, error) {

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -142,6 +142,34 @@ func TestInitCodexCreatesToml(t *testing.T) {
 	}
 }
 
+func TestInitCodexRecapOnPrintsCdxAliasHint(t *testing.T) {
+	home := tempHome(t)
+	stdout, _, code := runInitWithHome(t, home, "--target=codex", "--recap=on")
+	if code != 0 {
+		t.Fatalf("exit %d", code)
+	}
+	for _, want := range []string{
+		"cdx",
+		"alias cdx=",
+		"adapters/codex/wrapper/cdx",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("recap=on stdout should mention %q:\n%s", want, stdout)
+		}
+	}
+}
+
+func TestInitCodexRecapOffSkipsCdxAliasHint(t *testing.T) {
+	home := tempHome(t)
+	stdout, _, code := runInitWithHome(t, home, "--target=codex", "--recap=off")
+	if code != 0 {
+		t.Fatalf("exit %d", code)
+	}
+	if strings.Contains(stdout, "alias cdx=") {
+		t.Errorf("recap=off should not print cdx alias hint:\n%s", stdout)
+	}
+}
+
 func TestInitMissingTarget(t *testing.T) {
 	home := tempHome(t)
 	_, errOut, code := runInitWithHome(t, home)


### PR DESCRIPTION
## Summary

Closes #6.

Adds the Codex adapter assets — Mode A skill + per-agent invocation pin, and a shell wrapper for Mode B recap (since Codex has no Stop-equivalent hook).

### Mode A
- `adapters/codex/skills/scripture-lookup/SKILL.md` — manual fallback skill, contains no scripture text (verse content is fetched from the bundled MCP at runtime).
- `adapters/codex/skills/scripture-lookup/agents/openai.yaml` — pins `allow_implicit_invocation: false` for the OpenAI/Codex model (Codex equivalent of Claude's `disable-model-invocation: true`).
- `[features] codex_hooks = true` and the `UserPromptSubmit` hook live in the `config.toml` snippet `init --target=codex` already writes (issue #4); the inline `[[bible:John 3:16]]` marker is recognized by `lookup-from-prompt`.

### Mode B
- `adapters/codex/wrapper/cdx` (POSIX bash) and `adapters/codex/wrapper/cdx.ps1` (PowerShell) wrap `codex`, capture its exit code, then run `scripture-mcp recap --terminal` and exit with the captured code. Recap fires on success and on non-zero exit.
- `scripture-mcp init --target=codex --recap=on` now prints the alias-setup instructions for the wrapper. (We do not auto-edit the user's shell rc files.)
- README documents the limitation honestly: launching `codex` directly bypasses the recap. This is a deliberate physical-isolation trade-off — it guarantees the recap text can never enter a future Codex `model_call` input.

### Codex skill path
README explicitly notes the official-docs / OSS-repo disagreement on `~/.codex/skills` vs `$CODEX_HOME/skills` vs `~/.agents/skills`. We use `~/.codex/skills` to match the same `~/.codex/config.toml` location `init` writes to.

### Tests
- `adapters/adapters_test.go`: structural assertions on the skill, the `agents/openai.yaml` pin, and both wrappers (capture exit → recap → exit with captured code).
- Skill body is verified scripture-free against every bundled verse.
- `internal/cli/init_test.go`: `--target=codex --recap=on` prints the cdx alias hint; `--recap=off` does not.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go vet ./...`
- [ ] Manual smoke: `cdx --help` → recap fires after `codex --help` exits (requires a real `codex` install; not exercised in CI)


---
_Generated by [Claude Code](https://claude.ai/code/session_01J4HJvXmbJBa6pJf79EEv5a)_