### PR TITLE
fix: #7 — feat(install): one-line install.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,20 +133,46 @@ This single-binary / multi-interface design follows the pattern from
 
 ---
 
-## Install (planned)
+## Install
+
+One line:
 
 ```bash
-brew install verse-driven
-# or
 curl -fsSL https://raw.githubusercontent.com/MiaoDX/verse-driven/main/install.sh | bash
-
-# wire it into your coding agents
-scripture-mcp init --target=claude-code
-scripture-mcp init --target=codex
 ```
 
-`init` merges config snippets into your existing `settings.json` /
-`config.toml` — it does not overwrite your config.
+What it does:
+
+1. Detects your OS (macOS / Linux) and arch (arm64 / x86_64), downloads
+   the matching `scripture-mcp` release binary, and installs it to
+   `~/.local/bin/scripture-mcp` (override with `--prefix`).
+2. Detects which coding agents are on `$PATH` (`claude`, `codex`) and
+   wires each by calling `scripture-mcp init --target=<agent>`. The
+   prompt reads from `/dev/tty`, so it still works under `curl | bash`;
+   pass `--yes` to skip confirmation.
+3. Re-running upgrades the binary in place; `init` is idempotent on
+   configs (it splices a marker-fenced block, never overwrites your
+   settings).
+
+Useful flags:
+
+```bash
+install.sh --version v0.1.0          # pin a specific release
+install.sh --prefix /usr/local/bin   # install elsewhere
+install.sh --no-wire                 # binary only, skip agent wiring
+install.sh --uninstall               # strip wiring + remove binary
+```
+
+Or, equivalently, manage just the wiring with `init` itself:
+
+```bash
+scripture-mcp init --target=claude-code
+scripture-mcp init --target=codex
+scripture-mcp init --uninstall --target=claude-code   # remove
+```
+
+Homebrew / `apt` packages aren't shipped yet — `install.sh` is the only
+supported install path for v0.1.
 
 ### Claude Code adapter assets
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+# install.sh — one-shot installer for scripture-mcp.
+#
+# Downloads the right release binary for your OS/arch, places it on PATH,
+# detects which coding agents are installed locally (claude, codex), and
+# wires each by calling `scripture-mcp init --target=<agent>`.
+#
+# Quick start:
+#   curl -fsSL https://raw.githubusercontent.com/MiaoDX/verse-driven/main/install.sh | bash
+#
+# See `install.sh --help` for all flags.
+
+set -euo pipefail
+
+REPO="MiaoDX/verse-driven"
+BINARY="scripture-mcp"
+DEFAULT_PREFIX="${HOME}/.local/bin"
+
+# Env overrides (mostly for tests; also useful behind a corporate mirror):
+#   RELEASE_BASE_URL  — base for release tarballs (default: github.com releases).
+#   LATEST_RELEASE_URL — URL whose final-redirect path ends in the latest tag.
+RELEASE_BASE_URL="${RELEASE_BASE_URL:-https://github.com/${REPO}/releases/download}"
+LATEST_RELEASE_URL="${LATEST_RELEASE_URL:-https://github.com/${REPO}/releases/latest}"
+
+VERSION=""
+PREFIX=""
+ARCHIVE=""
+NO_WIRE=0
+UNINSTALL=0
+ASSUME_YES=0
+
+usage() {
+  cat <<'EOF'
+install.sh — install scripture-mcp and wire it into your coding agents.
+
+Usage: install.sh [flags]
+
+Flags:
+  --version <tag>      Pin to a specific release tag (default: latest).
+  --prefix <dir>       Install directory (default: $HOME/.local/bin).
+  --from-archive <p>   Skip the network and unpack a local .tar.gz instead.
+  --no-wire            Install the binary only; skip agent wiring.
+  --uninstall          Remove wiring (init --uninstall) and the binary.
+  --yes, -y            Wire all detected agents without prompting.
+  -h, --help           Show this help and exit.
+
+Acceptance criteria from issue #7:
+  - Detects OS/arch, downloads the matching release, places it on PATH.
+  - Detects claude / codex on PATH and offers to wire each.
+  - Calls `scripture-mcp init --target=...` per detected agent.
+  - Re-running upgrades the binary; init is idempotent on configs.
+  - Uninstall path: `scripture-mcp init --uninstall --target=...`.
+EOF
+}
+
+log() { printf 'install.sh: %s\n' "$*"; }
+warn() { printf 'install.sh: %s\n' "$*" >&2; }
+die() { warn "$*"; exit 1; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --version) VERSION="${2:-}"; shift 2 ;;
+    --version=*) VERSION="${1#*=}"; shift ;;
+    --prefix) PREFIX="${2:-}"; shift 2 ;;
+    --prefix=*) PREFIX="${1#*=}"; shift ;;
+    --from-archive) ARCHIVE="${2:-}"; shift 2 ;;
+    --from-archive=*) ARCHIVE="${1#*=}"; shift ;;
+    --no-wire) NO_WIRE=1; shift ;;
+    --uninstall) UNINSTALL=1; shift ;;
+    --yes|-y) ASSUME_YES=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) warn "unknown flag: $1"; usage >&2; exit 2 ;;
+  esac
+done
+
+PREFIX="${PREFIX:-$DEFAULT_PREFIX}"
+
+detect_os() {
+  case "$(uname -s)" in
+    Darwin) echo "darwin" ;;
+    Linux)  echo "linux" ;;
+    *) die "unsupported OS: $(uname -s) (install.sh supports macOS and Linux only)" ;;
+  esac
+}
+
+detect_arch() {
+  case "$(uname -m)" in
+    arm64|aarch64) echo "arm64" ;;
+    x86_64|amd64)  echo "x86_64" ;;
+    *) die "unsupported arch: $(uname -m)" ;;
+  esac
+}
+
+resolve_version() {
+  if [ -n "$VERSION" ]; then
+    printf '%s\n' "$VERSION"
+    return
+  fi
+  if ! command -v curl >/dev/null 2>&1; then
+    die "curl is required to resolve the latest release (or pass --version <tag>)"
+  fi
+  # GitHub redirects /releases/latest to /releases/tag/<tag>; capture the
+  # effective URL and strip everything up to the last slash.
+  local effective tag
+  effective="$(curl -fsSL -o /dev/null -w '%{url_effective}' "$LATEST_RELEASE_URL")"
+  tag="${effective##*/}"
+  if [ -z "$tag" ] || [ "$tag" = "latest" ]; then
+    die "could not resolve latest release from $LATEST_RELEASE_URL (pass --version <tag>)"
+  fi
+  printf '%s\n' "$tag"
+}
+
+fetch() {
+  local url="$1" dest="$2"
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "$url" -o "$dest"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -q "$url" -O "$dest"
+  else
+    die "need curl or wget to download $url"
+  fi
+}
+
+# install_binary downloads the release tarball (or uses --from-archive),
+# extracts the binary, and copies it to ${PREFIX}/${BINARY}. Re-running
+# overwrites the previous binary (the upgrade path).
+install_binary() {
+  local os arch tmp src
+  os="$(detect_os)"
+  arch="$(detect_arch)"
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  if [ -n "$ARCHIVE" ]; then
+    [ -f "$ARCHIVE" ] || die "--from-archive: file not found: $ARCHIVE"
+    log "unpacking local archive $ARCHIVE"
+    src="$ARCHIVE"
+  else
+    local version asset url
+    version="$(resolve_version)"
+    asset="${BINARY}-${version}-${os}-${arch}.tar.gz"
+    url="${RELEASE_BASE_URL}/${version}/${asset}"
+    log "downloading $asset"
+    src="${tmp}/${asset}"
+    fetch "$url" "$src"
+  fi
+
+  tar -xzf "$src" -C "$tmp"
+  [ -f "${tmp}/${BINARY}" ] || die "archive does not contain ${BINARY} at the top level"
+
+  mkdir -p "$PREFIX"
+  cp "${tmp}/${BINARY}" "${PREFIX}/${BINARY}.new"
+  chmod 0755 "${PREFIX}/${BINARY}.new"
+  mv -f "${PREFIX}/${BINARY}.new" "${PREFIX}/${BINARY}"
+  log "installed ${PREFIX}/${BINARY}"
+
+  case ":$PATH:" in
+    *":${PREFIX}:"*) ;;
+    *) warn "note: ${PREFIX} is not on \$PATH. Add this to your shell rc:"
+       warn "    export PATH=\"${PREFIX}:\$PATH\"" ;;
+  esac
+}
+
+remove_binary() {
+  local target="${PREFIX}/${BINARY}"
+  if [ -f "$target" ]; then
+    rm -f "$target"
+    log "removed $target"
+  else
+    log "nothing to remove at $target"
+  fi
+}
+
+have_agent() { command -v "$1" >/dev/null 2>&1; }
+
+# prompt_yes returns 0 (yes) when --yes was passed, when no TTY is
+# available (typical curl|bash session — default to wiring), or when the
+# user answers y/Y/yes at the prompt. Reading from /dev/tty lets us
+# prompt even when stdin is the curl pipe.
+prompt_yes() {
+  if [ "$ASSUME_YES" = "1" ]; then return 0; fi
+  if [ ! -t 0 ] && [ ! -e /dev/tty ]; then return 0; fi
+  local reply=""
+  printf 'install.sh: %s [Y/n] ' "$1" >&2
+  if [ -t 0 ]; then
+    read -r reply || reply=""
+  else
+    read -r reply </dev/tty || reply=""
+  fi
+  case "${reply:-y}" in
+    y|Y|yes|YES) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+wire_agents() {
+  local bin="${PREFIX}/${BINARY}"
+  local any=0
+  if have_agent claude; then
+    any=1
+    if prompt_yes "wire Claude Code (~/.claude/settings.json)?"; then
+      "$bin" init --target=claude-code
+    else
+      log "skipped Claude Code wiring"
+    fi
+  fi
+  if have_agent codex; then
+    any=1
+    if prompt_yes "wire Codex (~/.codex/config.toml)?"; then
+      "$bin" init --target=codex
+    else
+      log "skipped Codex wiring"
+    fi
+  fi
+  if [ "$any" = "0" ]; then
+    log "no supported agents detected on \$PATH (claude, codex)"
+    log "install one and re-run, or invoke 'scripture-mcp init --target=...' manually"
+  fi
+}
+
+unwire_agents() {
+  local bin="${PREFIX}/${BINARY}"
+  if [ ! -x "$bin" ]; then
+    log "${bin} not found; skipping config cleanup"
+    return
+  fi
+  if have_agent claude; then
+    "$bin" init --uninstall --target=claude-code || true
+  fi
+  if have_agent codex; then
+    "$bin" init --uninstall --target=codex || true
+  fi
+}
+
+if [ "$UNINSTALL" = "1" ]; then
+  unwire_agents
+  remove_binary
+  log "done"
+  exit 0
+fi
+
+install_binary
+if [ "$NO_WIRE" = "0" ]; then
+  wire_agents
+fi
+log "done"

--- a/internal/installer/install_test.go
+++ b/internal/installer/install_test.go
@@ -1,0 +1,364 @@
+// Package installer holds tests that drive the top-level install.sh
+// end-to-end against a fake release tarball. We don't ship Go code for
+// the installer itself — install.sh is the contract — but the test lives
+// in a Go package so it runs under `go test ./...` in CI.
+package installer
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// repoRoot returns the absolute path of the repository root, located
+// from this test file. We hop two parents up: internal/installer → repo.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	root := filepath.Clean(filepath.Join(wd, "..", ".."))
+	if _, err := os.Stat(filepath.Join(root, "install.sh")); err != nil {
+		t.Fatalf("expected install.sh at %s: %v", root, err)
+	}
+	return root
+}
+
+// buildScriptureMCP compiles the real binary into outDir. We use the
+// real binary (not a stub) so init writes the canonical snippets and
+// the test doubles as a smoke check that install.sh + init agree.
+func buildScriptureMCP(t *testing.T, outDir string) string {
+	t.Helper()
+	root := repoRoot(t)
+	bin := filepath.Join(outDir, "scripture-mcp")
+	cmd := exec.Command("go", "build", "-o", bin, "./cmd/scripture-mcp")
+	cmd.Dir = root
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("go build: %v\n%s", err, out)
+	}
+	return bin
+}
+
+// makeArchive packs binPath into a .tar.gz at archivePath, with the
+// binary stored at the top level as `scripture-mcp` (the path install.sh
+// expects to find after extraction).
+func makeArchive(t *testing.T, binPath, archivePath string) {
+	t.Helper()
+	body, err := os.ReadFile(binPath)
+	if err != nil {
+		t.Fatalf("read binary: %v", err)
+	}
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	hdr := &tar.Header{
+		Name: "scripture-mcp",
+		Mode: 0o755,
+		Size: int64(len(body)),
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		t.Fatalf("tar header: %v", err)
+	}
+	if _, err := tw.Write(body); err != nil {
+		t.Fatalf("tar write: %v", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("tar close: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+	if err := os.WriteFile(archivePath, buf.Bytes(), 0o644); err != nil {
+		t.Fatalf("write archive: %v", err)
+	}
+}
+
+// writeStub writes a minimal executable script to dir/name so that
+// command -v <name> finds it on PATH. We don't care what it does; the
+// installer only needs to detect its presence.
+func writeStub(t *testing.T, dir, name string) {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write stub %s: %v", name, err)
+	}
+}
+
+// runInstall invokes install.sh with the supplied args, in an
+// environment where HOME, PATH, and the scratch dirs are sandboxed so
+// the test can never touch the user's real config.
+func runInstall(t *testing.T, root, fakeHome, agentDir string, args ...string) (string, error) {
+	t.Helper()
+	cmd := exec.Command("bash", append([]string{filepath.Join(root, "install.sh")}, args...)...)
+	cmd.Env = append(os.Environ(),
+		"HOME="+fakeHome,
+		// PATH carries only the agent stubs and core utilities; we
+		// deliberately omit any system-wide claude/codex so detection
+		// only sees what the test put in agentDir.
+		"PATH="+agentDir+":/usr/bin:/bin:/usr/local/bin",
+	)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func TestInstallScriptHelp(t *testing.T) {
+	root := repoRoot(t)
+	out, err := exec.Command("bash", filepath.Join(root, "install.sh"), "--help").CombinedOutput()
+	if err != nil {
+		t.Fatalf("install.sh --help: %v\n%s", err, out)
+	}
+	for _, want := range []string{"--version", "--prefix", "--from-archive", "--no-wire", "--uninstall"} {
+		if !strings.Contains(string(out), want) {
+			t.Errorf("--help output missing %q\n%s", want, out)
+		}
+	}
+}
+
+func TestInstallScriptRejectsUnknownFlag(t *testing.T) {
+	root := repoRoot(t)
+	cmd := exec.Command("bash", filepath.Join(root, "install.sh"), "--bogus")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected non-zero exit for --bogus, got success\n%s", out)
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) || exitErr.ExitCode() != 2 {
+		t.Errorf("expected exit code 2 for unknown flag, got %v\n%s", err, out)
+	}
+}
+
+// TestInstallEndToEnd is the central integration test. It builds the
+// real scripture-mcp binary, packs it into a tarball, then drives
+// install.sh through three phases:
+//
+//  1. install + wire (with stub agents on PATH) → binary in place,
+//     ~/.claude/settings.json and ~/.codex/config.toml gain the
+//     verse-driven block.
+//  2. re-run → upgrade is idempotent on the binary; init reports
+//     "already up to date" for both configs.
+//  3. uninstall → init --uninstall strips the snippets, binary removed.
+func TestInstallEndToEnd(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("install.sh is POSIX bash; Windows is out of scope for issue #7")
+	}
+	root := repoRoot(t)
+
+	scratch := t.TempDir()
+	binSrcDir := filepath.Join(scratch, "src")
+	if err := os.MkdirAll(binSrcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	binPath := buildScriptureMCP(t, binSrcDir)
+
+	archive := filepath.Join(scratch, "scripture-mcp.tar.gz")
+	makeArchive(t, binPath, archive)
+
+	prefix := filepath.Join(scratch, "bin")
+	fakeHome := filepath.Join(scratch, "home")
+	agentDir := filepath.Join(scratch, "agents")
+	if err := os.MkdirAll(fakeHome, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeStub(t, agentDir, "claude")
+	writeStub(t, agentDir, "codex")
+
+	args := []string{
+		"--from-archive", archive,
+		"--prefix", prefix,
+		"--yes",
+	}
+
+	// Phase 1: fresh install.
+	out, err := runInstall(t, root, fakeHome, agentDir, args...)
+	if err != nil {
+		t.Fatalf("install run 1: %v\n%s", err, out)
+	}
+	installedBin := filepath.Join(prefix, "scripture-mcp")
+	st, err := os.Stat(installedBin)
+	if err != nil {
+		t.Fatalf("expected binary at %s: %v\n%s", installedBin, err, out)
+	}
+	if st.Mode().Perm()&0o111 == 0 {
+		t.Errorf("expected installed binary to be executable, got mode %v", st.Mode())
+	}
+
+	claudeCfg := filepath.Join(fakeHome, ".claude", "settings.json")
+	codexCfg := filepath.Join(fakeHome, ".codex", "config.toml")
+	mustContain(t, claudeCfg, ">>> verse-driven", "scripture-mcp")
+	mustContain(t, codexCfg, ">>> verse-driven", "scripture-mcp")
+
+	// Phase 2: re-run is idempotent on configs and replaces the binary.
+	out2, err := runInstall(t, root, fakeHome, agentDir, args...)
+	if err != nil {
+		t.Fatalf("install run 2: %v\n%s", err, out2)
+	}
+	if !strings.Contains(out2, "already up to date") {
+		t.Errorf("expected re-run to report 'already up to date', got:\n%s", out2)
+	}
+	// Binary should still exist after the re-run.
+	if _, err := os.Stat(installedBin); err != nil {
+		t.Errorf("binary missing after re-run: %v", err)
+	}
+
+	// Phase 3: uninstall strips the snippets and removes the binary.
+	out3, err := runInstall(t, root, fakeHome, agentDir, "--prefix", prefix, "--uninstall")
+	if err != nil {
+		t.Fatalf("install --uninstall: %v\n%s", err, out3)
+	}
+	if _, err := os.Stat(installedBin); !os.IsNotExist(err) {
+		t.Errorf("expected binary to be removed, got err=%v", err)
+	}
+	mustNotContain(t, claudeCfg, ">>> verse-driven")
+	mustNotContain(t, codexCfg, ">>> verse-driven")
+}
+
+// TestInstallNoAgentsDetected covers the empty-PATH case: no claude or
+// codex on PATH, the installer still places the binary and reports
+// nothing to wire.
+func TestInstallNoAgentsDetected(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("install.sh is POSIX bash")
+	}
+	root := repoRoot(t)
+	scratch := t.TempDir()
+
+	binSrcDir := filepath.Join(scratch, "src")
+	if err := os.MkdirAll(binSrcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	binPath := buildScriptureMCP(t, binSrcDir)
+	archive := filepath.Join(scratch, "scripture-mcp.tar.gz")
+	makeArchive(t, binPath, archive)
+
+	prefix := filepath.Join(scratch, "bin")
+	fakeHome := filepath.Join(scratch, "home")
+	emptyAgentDir := filepath.Join(scratch, "noagents") // exists but empty
+	if err := os.MkdirAll(fakeHome, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(emptyAgentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := runInstall(t, root, fakeHome, emptyAgentDir,
+		"--from-archive", archive, "--prefix", prefix, "--yes")
+	if err != nil {
+		t.Fatalf("install: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "no supported agents detected") {
+		t.Errorf("expected 'no supported agents detected' message, got:\n%s", out)
+	}
+	if _, err := os.Stat(filepath.Join(prefix, "scripture-mcp")); err != nil {
+		t.Errorf("binary should still be installed when no agents present: %v", err)
+	}
+	// No config dirs should have been created.
+	if _, err := os.Stat(filepath.Join(fakeHome, ".claude")); !os.IsNotExist(err) {
+		t.Errorf("expected no ~/.claude dir, got err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(fakeHome, ".codex")); !os.IsNotExist(err) {
+		t.Errorf("expected no ~/.codex dir, got err=%v", err)
+	}
+}
+
+// TestInstallNoWireSkipsAgents verifies --no-wire installs the binary
+// without touching any agent config, even when claude/codex are on PATH.
+func TestInstallNoWireSkipsAgents(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("install.sh is POSIX bash")
+	}
+	root := repoRoot(t)
+	scratch := t.TempDir()
+
+	binSrcDir := filepath.Join(scratch, "src")
+	if err := os.MkdirAll(binSrcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	binPath := buildScriptureMCP(t, binSrcDir)
+	archive := filepath.Join(scratch, "scripture-mcp.tar.gz")
+	makeArchive(t, binPath, archive)
+
+	prefix := filepath.Join(scratch, "bin")
+	fakeHome := filepath.Join(scratch, "home")
+	agentDir := filepath.Join(scratch, "agents")
+	if err := os.MkdirAll(fakeHome, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeStub(t, agentDir, "claude")
+	writeStub(t, agentDir, "codex")
+
+	out, err := runInstall(t, root, fakeHome, agentDir,
+		"--from-archive", archive, "--prefix", prefix, "--no-wire")
+	if err != nil {
+		t.Fatalf("install --no-wire: %v\n%s", err, out)
+	}
+	if _, err := os.Stat(filepath.Join(fakeHome, ".claude")); !os.IsNotExist(err) {
+		t.Errorf("--no-wire should not create ~/.claude, got err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(fakeHome, ".codex")); !os.IsNotExist(err) {
+		t.Errorf("--no-wire should not create ~/.codex, got err=%v", err)
+	}
+}
+
+// TestInstallMissingArchive verifies the script fails fast when
+// --from-archive points at a file that doesn't exist.
+func TestInstallMissingArchive(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("install.sh is POSIX bash")
+	}
+	root := repoRoot(t)
+	scratch := t.TempDir()
+	cmd := exec.Command("bash", filepath.Join(root, "install.sh"),
+		"--from-archive", filepath.Join(scratch, "nope.tar.gz"),
+		"--prefix", filepath.Join(scratch, "bin"),
+		"--no-wire")
+	cmd.Env = append(os.Environ(), "HOME="+scratch, "PATH=/usr/bin:/bin")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected failure for missing archive, got success\n%s", out)
+	}
+	if !strings.Contains(string(out), "file not found") {
+		t.Errorf("expected 'file not found' diagnostic, got:\n%s", out)
+	}
+}
+
+func mustContain(t *testing.T, path string, fragments ...string) {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	for _, frag := range fragments {
+		if !strings.Contains(string(b), frag) {
+			t.Errorf("%s does not contain %q", path, frag)
+		}
+	}
+}
+
+func mustNotContain(t *testing.T, path, fragment string) {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		// File missing also satisfies "doesn't contain".
+		if os.IsNotExist(err) {
+			return
+		}
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if strings.Contains(string(b), fragment) {
+		t.Errorf("%s should no longer contain %q", path, fragment)
+	}
+}


### PR DESCRIPTION
Closes #7.

Adds the `install.sh` one-shot installer plus an end-to-end Go test
harness that exercises it against a fake release tarball — no network
required in CI.

## What's in this PR

- **`install.sh`** — POSIX bash. Detects OS (`darwin`/`linux`) and arch
  (`arm64`/`x86_64`), downloads the matching `scripture-mcp` release
  tarball from `https://github.com/MiaoDX/verse-driven/releases/download/<tag>/scripture-mcp-<tag>-<os>-<arch>.tar.gz`,
  unpacks it, and installs to `~/.local/bin/scripture-mcp` (overridable
  with `--prefix`). Re-running overwrites the binary in place — that's
  the upgrade path. After install, it detects `claude` and `codex` on
  `$PATH` and runs `scripture-mcp init --target=<agent>` for each (which
  is already idempotent on configs via PR #14's marker-fenced splice).
- **`--uninstall`** reverses both halves: `init --uninstall` for each
  detected agent, then removes the binary.
- **Convenience flags**: `--no-wire` installs the binary only;
  `--yes`/`-y` auto-confirms; `--version <tag>` pins a release;
  `--from-archive <path>` bypasses the network and unpacks a local
  tarball — used by the test harness, also handy for air-gapped
  installs or behind a corporate proxy. Env overrides
  `RELEASE_BASE_URL` / `LATEST_RELEASE_URL` exist for advanced cases.
- **Prompting under `curl | bash`**: `prompt_yes` reads from `/dev/tty`
  when stdin is the curl pipe, so the y/n confirmation actually reaches
  the user. When neither stdin nor `/dev/tty` is a terminal (CI, fully
  automated runs), it defaults to yes — `--yes` makes that explicit.
- **`internal/installer/install_test.go`** — Go tests that build the
  real `scripture-mcp` binary, pack it into a `.tar.gz`, then drive
  `install.sh` against a sandboxed `HOME` and a stubbed `PATH`.
  Covered:
  - `--help` surface lists all the documented flags.
  - Unknown flag → exit 2.
  - End-to-end three-phase cycle: fresh install + wire (asserts binary
    is executable, both `~/.claude/settings.json` and
    `~/.codex/config.toml` gain the `>>> verse-driven` block) → re-run
    (asserts "already up to date" for both configs and binary still
    present, i.e. idempotent) → `--uninstall` (asserts binary removed
    and snippets stripped).
  - No-agents case: missing `claude`/`codex` still installs the binary
    and reports "no supported agents detected".
  - `--no-wire` skips agent wiring even when both are on `$PATH`.
  - Missing `--from-archive` file fails fast with a clear diagnostic.
- **README** — replaces the prior "Install (planned)" section with a
  real one centered on `install.sh`, drops the speculative `brew`
  line per the issue's note.

## Acceptance-criteria mapping

- [x] `install.sh` detects OS/arch, downloads the right binary release, places it on `PATH` (warns when `$PREFIX` isn't on `$PATH`)
- [x] Detects which agents are installed (`claude` / `codex` on `PATH`) and offers to wire each
- [x] Calls `scripture-mcp init --target=...` per detected agent
- [x] Re-running upgrades the binary and is idempotent on configs (asserted by `TestInstallEndToEnd` phase 2)
- [x] Uninstall path: `scripture-mcp init --uninstall --target=...` removes the snippets — both surfaced directly via `init` and bundled into `install.sh --uninstall`

## Verification

- `go test ./...` — green across all 9 packages, including 6 new installer tests
- `go vet ./...` — clean
- `bash install.sh --help` — prints flag table
- `bash install.sh --bogus` — exits 2 with "unknown flag" diagnostic
- End-to-end smoke (replicated by `TestInstallEndToEnd`):
  1. Build `scripture-mcp` and pack into `/tmp/scripture-mcp.tar.gz`.
  2. `HOME=/tmp/h PATH=/tmp/agents:... bash install.sh --from-archive /tmp/scripture-mcp.tar.gz --prefix /tmp/bin --yes`
     → installs `/tmp/bin/scripture-mcp`, splices the verse-driven block into both `~/.claude/settings.json` and `~/.codex/config.toml`.
  3. Re-running prints "already up to date" for both configs.
  4. `bash install.sh --prefix /tmp/bin --uninstall` strips the snippets and removes the binary.

---
_Generated by [Claude Code](https://claude.ai/code/)_