### PR TITLE
test(bench): vendor 9 remaining benchmark fixtures for issue #8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bin/
 *.test
 *.out
 .DS_Store
+.bench-scratch/

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ bin/
 *.out
 .DS_Store
 .bench-scratch/
+__pycache__/
+*.pyc

--- a/docs/benchmarks/fixtures/bugfix-off-by-one/README.md
+++ b/docs/benchmarks/fixtures/bugfix-off-by-one/README.md
@@ -19,8 +19,5 @@ The agent's prompt for this task is the `description` field in
 copied) read-write before the run; tests run against the post-edit
 state.
 
-## Remaining fixtures
-
-The other nine fixtures referenced by `tasks.json` follow the same
-convention but are not yet vendored. Adding them is tracked as part
-of the remaining work for issue #8 — see the issue's checklist.
+All ten fixtures referenced by `tasks.json` follow this same
+convention; this directory is the original template.

--- a/docs/benchmarks/fixtures/bugfix-off-by-one/README.md
+++ b/docs/benchmarks/fixtures/bugfix-off-by-one/README.md
@@ -1,0 +1,26 @@
+# bugfix-off-by-one (benchmark fixture)
+
+Reference fixture for the issue #8 coding-quality benchmark task pack.
+Each fixture in this directory follows the same convention so the
+runner can drive every task uniformly.
+
+## Convention
+
+- `<fixture>/` — the working directory the agent operates in.
+- One or more source files containing the seed code (here:
+  `windows.py`).
+- `test_<name>.py` — acceptance tests. The runner grades a task by
+  running `pytest -q` after the agent finishes editing.
+- `README.md` (this file) — what the agent is told to do, in the
+  same form a real PR description might take.
+
+The agent's prompt for this task is the `description` field in
+`docs/benchmarks/tasks.json`. The fixture directory is mounted (or
+copied) read-write before the run; tests run against the post-edit
+state.
+
+## Remaining fixtures
+
+The other nine fixtures referenced by `tasks.json` follow the same
+convention but are not yet vendored. Adding them is tracked as part
+of the remaining work for issue #8 — see the issue's checklist.

--- a/docs/benchmarks/fixtures/bugfix-off-by-one/test_windows.py
+++ b/docs/benchmarks/fixtures/bugfix-off-by-one/test_windows.py
@@ -1,0 +1,29 @@
+"""Acceptance tests for bugfix-off-by-one. The benchmark runner grades
+a task by running pytest -q against this file after the agent edits
+windows.py.
+"""
+
+import pytest
+
+from windows import rolling_sum
+
+
+def test_window_1_returns_full_length():
+    assert rolling_sum([1, 2, 3, 4], 1) == [1, 2, 3, 4]
+
+
+def test_window_2():
+    assert rolling_sum([1, 2, 3, 4], 2) == [3, 5, 7]
+
+
+def test_window_equals_input_length():
+    assert rolling_sum([1, 2, 3, 4], 4) == [10]
+
+
+def test_window_zero_raises():
+    with pytest.raises(ValueError):
+        rolling_sum([1, 2, 3], 0)
+
+
+def test_empty_input_returns_empty():
+    assert rolling_sum([], 3) == []

--- a/docs/benchmarks/fixtures/bugfix-off-by-one/windows.py
+++ b/docs/benchmarks/fixtures/bugfix-off-by-one/windows.py
@@ -1,0 +1,13 @@
+"""Rolling-window aggregation. There is an off-by-one bug for window=1.
+
+This is the seed file the agent edits during a benchmark run.
+"""
+
+
+def rolling_sum(xs, window):
+    if window < 1:
+        raise ValueError("window must be >= 1")
+    out = []
+    for i in range(window, len(xs)):
+        out.append(sum(xs[i - window:i]))
+    return out

--- a/docs/benchmarks/fixtures/bugfix-race-counter/README.md
+++ b/docs/benchmarks/fixtures/bugfix-race-counter/README.md
@@ -1,0 +1,12 @@
+# bugfix-race-counter (benchmark fixture)
+
+Make ``Counter`` thread-safe. Concurrent ``increment`` and ``add``
+calls from many threads must never lose updates. The public API
+(``Counter``, ``increment``, ``add``, ``value``) must not change.
+
+A ``threading.Lock`` around the read-modify-write is the canonical
+fix; alternative approaches (``threading.RLock``, atomic primitives
+from ``itertools.count`` semantics, etc.) are acceptable as long as
+the tests pass.
+
+Acceptance command: ``pytest -q``.

--- a/docs/benchmarks/fixtures/bugfix-race-counter/counter.py
+++ b/docs/benchmarks/fixtures/bugfix-race-counter/counter.py
@@ -1,0 +1,38 @@
+"""Thread-shared counter with a concurrency bug.
+
+The current ``Counter.add`` does an explicit read-modify-write with a
+small ``time.sleep(0)`` between the read and the write — a classic
+non-atomic pattern that races even under the CPython GIL because the
+sleep is a guaranteed thread-yield point. Many concurrent ``add``
+calls will therefore lose updates.
+
+The agent must make the counter thread-safe (e.g. with a
+``threading.Lock`` around the read-modify-write) without changing the
+public API.
+
+Public API to preserve:
+
+  Counter()             - construct a new counter at zero
+  Counter().increment() - add one
+  Counter().add(n)      - add n
+  Counter().value       - read the current count
+"""
+
+import time
+
+
+class Counter:
+    def __init__(self):
+        self._n = 0
+
+    def increment(self):
+        self.add(1)
+
+    def add(self, n):
+        cur = self._n
+        time.sleep(0)  # force a GIL release between read and write
+        self._n = cur + n
+
+    @property
+    def value(self):
+        return self._n

--- a/docs/benchmarks/fixtures/bugfix-race-counter/test_counter.py
+++ b/docs/benchmarks/fixtures/bugfix-race-counter/test_counter.py
@@ -1,0 +1,57 @@
+"""Acceptance tests for bugfix-race-counter.
+
+Passes when concurrent increments from many threads land the right
+total. The single-threaded contract still holds.
+"""
+
+import threading
+
+from counter import Counter
+
+
+def test_single_threaded_increment():
+    c = Counter()
+    for _ in range(100):
+        c.increment()
+    assert c.value == 100
+
+
+def test_single_threaded_add():
+    c = Counter()
+    c.add(7)
+    c.add(3)
+    assert c.value == 10
+
+
+def test_concurrent_increment_no_lost_updates():
+    c = Counter()
+    n_threads = 16
+    per_thread = 5_000
+
+    def worker():
+        for _ in range(per_thread):
+            c.increment()
+
+    threads = [threading.Thread(target=worker) for _ in range(n_threads)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert c.value == n_threads * per_thread
+
+
+def test_concurrent_add_no_lost_updates():
+    c = Counter()
+    n_threads = 8
+    per_thread = 1_000
+
+    def worker():
+        for _ in range(per_thread):
+            c.add(3)
+
+    threads = [threading.Thread(target=worker) for _ in range(n_threads)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert c.value == n_threads * per_thread * 3

--- a/docs/benchmarks/fixtures/bugfix-utf8-truncate/README.md
+++ b/docs/benchmarks/fixtures/bugfix-utf8-truncate/README.md
@@ -1,0 +1,10 @@
+# bugfix-utf8-truncate (benchmark fixture)
+
+Fix ``truncate_bytes`` so it never returns bytes that split a UTF-8
+codepoint mid-sequence. The output must:
+
+  * have length ``<= n``,
+  * decode cleanly as UTF-8,
+  * be the longest valid prefix of the input that fits.
+
+Acceptance command: ``pytest -q``.

--- a/docs/benchmarks/fixtures/bugfix-utf8-truncate/test_truncate.py
+++ b/docs/benchmarks/fixtures/bugfix-utf8-truncate/test_truncate.py
@@ -1,0 +1,45 @@
+"""Acceptance tests for bugfix-utf8-truncate.
+
+Passes when ``truncate_bytes`` returns valid UTF-8 of length <= n that
+is the longest valid prefix of the input fitting in n bytes.
+"""
+
+import pytest
+
+from truncate import truncate_bytes
+
+
+def test_ascii_unchanged_when_budget_sufficient():
+    assert truncate_bytes("hello", 10) == b"hello"
+
+
+def test_ascii_clipped_at_byte_budget():
+    assert truncate_bytes("hello", 3) == b"hel"
+
+
+def test_multibyte_does_not_split_codepoint():
+    # "你" encodes to 3 bytes in UTF-8.
+    out = truncate_bytes("你好", 4)
+    assert len(out) <= 4
+    out.decode("utf-8")  # must not raise
+    assert out == "你".encode("utf-8")
+
+
+def test_emoji_does_not_split_codepoint():
+    # Smiling face emoji is 4 bytes in UTF-8.
+    out = truncate_bytes("ab😀cd", 4)
+    out.decode("utf-8")
+    assert out == b"ab"
+
+
+def test_zero_budget_returns_empty():
+    assert truncate_bytes("hello", 0) == b""
+
+
+def test_negative_budget_raises():
+    with pytest.raises(ValueError):
+        truncate_bytes("hi", -1)
+
+
+def test_full_string_when_budget_huge():
+    assert truncate_bytes("héllo", 100) == "héllo".encode("utf-8")

--- a/docs/benchmarks/fixtures/bugfix-utf8-truncate/truncate.py
+++ b/docs/benchmarks/fixtures/bugfix-utf8-truncate/truncate.py
@@ -1,0 +1,19 @@
+"""Truncate a string so its UTF-8 encoding fits a byte budget.
+
+There is a bug: the current implementation slices the encoded bytes at
+``n`` directly, which can land in the middle of a multi-byte UTF-8
+sequence and produce invalid UTF-8 (or, when decoded with errors set,
+a "replacement-character" suffix).
+
+The agent must fix ``truncate_bytes`` so the returned bytes:
+  * have length ``<= n``,
+  * decode cleanly as UTF-8,
+  * are the longest valid prefix of the input that fits.
+"""
+
+
+def truncate_bytes(s: str, n: int) -> bytes:
+    if n < 0:
+        raise ValueError("n must be >= 0")
+    encoded = s.encode("utf-8")
+    return encoded[:n]

--- a/docs/benchmarks/fixtures/feature-cli-flag/README.md
+++ b/docs/benchmarks/fixtures/feature-cli-flag/README.md
@@ -1,0 +1,10 @@
+# feature-cli-flag (benchmark fixture)
+
+Add an opt-in ``--json`` flag to ``tool.py`` that emits the same
+summary as a single JSON object on stdout. The default human-readable
+output must be unchanged.
+
+Add a ``render_json(summary) -> str`` helper that mirrors
+``render_text``.
+
+Acceptance command: ``pytest -q``.

--- a/docs/benchmarks/fixtures/feature-cli-flag/test_tool.py
+++ b/docs/benchmarks/fixtures/feature-cli-flag/test_tool.py
@@ -1,0 +1,40 @@
+"""Acceptance tests for feature-cli-flag.
+
+Passes when:
+  1. The default output (no --json) is unchanged.
+  2. ``--json`` emits a single JSON object with ``total``, ``count``,
+     ``top`` fields and nothing extra to stdout.
+  3. A ``render_json(summary) -> str`` helper exists.
+"""
+
+import json
+
+import tool
+from tool import main, render_text, summarize
+
+
+def test_summarize():
+    summary = summarize([("a", 1), ("b", 5), ("c", 2)])
+    assert summary == {"total": 8, "count": 3, "top": "b"}
+
+
+def test_default_output_unchanged(capsys):
+    rc = main(["apples=3", "bananas=7"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert out == render_text(summarize([("apples", 3), ("bananas", 7)]))
+
+
+def test_json_flag_emits_single_object(capsys):
+    rc = main(["--json", "apples=3", "bananas=7"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    body = json.loads(out)
+    assert body == {"total": 10, "count": 2, "top": "bananas"}
+
+
+def test_render_json_helper_exists():
+    assert hasattr(tool, "render_json"), "render_json helper not added"
+    summary = summarize([("a", 1)])
+    body = json.loads(tool.render_json(summary))
+    assert body == summary

--- a/docs/benchmarks/fixtures/feature-cli-flag/tool.py
+++ b/docs/benchmarks/fixtures/feature-cli-flag/tool.py
@@ -1,0 +1,63 @@
+"""A small CLI that summarizes a list of (name, count) pairs.
+
+Today it prints a human-readable summary. The agent is asked to add an
+opt-in ``--json`` flag that emits the same data as a single JSON
+object on stdout, while keeping the default human-readable output
+exactly as it is today.
+
+The summary is computed by ``summarize(items)`` and rendered for
+humans by ``render_text(summary)``. Add a ``render_json(summary)``
+that returns a JSON string with the same fields.
+
+Public functions to keep:
+  summarize(items) -> dict
+  render_text(summary) -> str
+  main(argv) -> int           # writes to stdout, returns exit code
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+
+def summarize(items):
+    total = sum(c for _, c in items)
+    top = max(items, key=lambda x: x[1])[0] if items else None
+    return {
+        "total": total,
+        "count": len(items),
+        "top": top,
+    }
+
+
+def render_text(summary):
+    return (
+        f"items: {summary['count']}\n"
+        f"total: {summary['total']}\n"
+        f"top: {summary['top']}\n"
+    )
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="summarize (name,count) pairs")
+    parser.add_argument(
+        "pairs",
+        nargs="*",
+        help="name=count tokens, e.g. apples=3 bananas=7",
+    )
+    args = parser.parse_args(argv)
+    items = []
+    for tok in args.pairs:
+        if "=" not in tok:
+            print(f"bad pair: {tok}", file=sys.stderr)
+            return 2
+        name, count = tok.split("=", 1)
+        items.append((name, int(count)))
+    summary = summarize(items)
+    sys.stdout.write(render_text(summary))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/benchmarks/fixtures/feature-flatten-json/README.md
+++ b/docs/benchmarks/fixtures/feature-flatten-json/README.md
@@ -1,0 +1,7 @@
+# feature-flatten-json (benchmark fixture)
+
+Implement ``flatten_json(obj, sep='.') -> dict``: nested dicts become
+dotted keys; lists become bracketed indices (``xs[0]``); scalars pass
+through. Non-dict top-level argument raises ``TypeError``.
+
+Acceptance command: ``pytest -q``.

--- a/docs/benchmarks/fixtures/feature-flatten-json/flatten.py
+++ b/docs/benchmarks/fixtures/feature-flatten-json/flatten.py
@@ -1,0 +1,22 @@
+"""flatten_json: turn nested JSON-shaped data into a flat dict.
+
+The agent is asked to implement ``flatten_json(obj, sep='.') -> dict``:
+
+  * Nested dicts: keys are joined with ``sep``.
+  * Lists: indices appear as ``[i]`` segments (no separator before
+    the bracket).
+  * Scalars (str, int, float, bool, None) are leaves.
+  * The top-level argument must be a dict; raise ``TypeError`` for
+    other shapes.
+
+Examples:
+
+    flatten_json({"a": {"b": 1}})           -> {"a.b": 1}
+    flatten_json({"xs": [10, 20]})          -> {"xs[0]": 10, "xs[1]": 20}
+    flatten_json({"a": {"b": [{"c": 1}]}})  -> {"a.b[0].c": 1}
+    flatten_json({}, sep='/')               -> {}
+"""
+
+
+def flatten_json(obj, sep="."):
+    raise NotImplementedError

--- a/docs/benchmarks/fixtures/feature-flatten-json/test_flatten.py
+++ b/docs/benchmarks/fixtures/feature-flatten-json/test_flatten.py
@@ -1,0 +1,42 @@
+"""Acceptance tests for feature-flatten-json. Four nesting shapes
+plus error cases.
+"""
+
+import pytest
+
+from flatten import flatten_json
+
+
+def test_flat_dict_passes_through():
+    assert flatten_json({"a": 1, "b": 2}) == {"a": 1, "b": 2}
+
+
+def test_nested_dicts_dotted():
+    assert flatten_json({"a": {"b": {"c": 9}}}) == {"a.b.c": 9}
+
+
+def test_list_uses_bracket_indices():
+    out = flatten_json({"xs": [10, 20, 30]})
+    assert out == {"xs[0]": 10, "xs[1]": 20, "xs[2]": 30}
+
+
+def test_mixed_dict_and_list():
+    out = flatten_json({"a": {"b": [{"c": 1}, {"d": 2}]}})
+    assert out == {"a.b[0].c": 1, "a.b[1].d": 2}
+
+
+def test_custom_separator():
+    assert flatten_json({"a": {"b": 1}}, sep="/") == {"a/b": 1}
+
+
+def test_empty_dict_yields_empty():
+    assert flatten_json({}) == {}
+
+
+def test_scalar_top_level_raises():
+    with pytest.raises(TypeError):
+        flatten_json(5)
+
+
+def test_none_value_preserved():
+    assert flatten_json({"a": None}) == {"a": None}

--- a/docs/benchmarks/fixtures/feature-rate-limit/README.md
+++ b/docs/benchmarks/fixtures/feature-rate-limit/README.md
@@ -1,0 +1,9 @@
+# feature-rate-limit (benchmark fixture)
+
+Implement ``TokenBucket(rate, burst)`` and a ``rate_limit(rate, burst)``
+decorator in ``limiter.py``. The bucket refills at ``rate`` tokens per
+second with capacity ``burst``; ``acquire(n)`` blocks, ``try_acquire(n)``
+returns immediately. The decorator wraps a function so each call
+``acquire(1)`` from a per-decorator bucket.
+
+Acceptance command: ``pytest -q``.

--- a/docs/benchmarks/fixtures/feature-rate-limit/limiter.py
+++ b/docs/benchmarks/fixtures/feature-rate-limit/limiter.py
@@ -1,0 +1,36 @@
+"""Token-bucket rate limiter — implementation TODO.
+
+The agent is asked to implement:
+
+  * ``TokenBucket(rate, burst)`` — a token bucket that refills at
+    ``rate`` tokens per second with capacity ``burst``. Method
+    ``acquire(n=1)`` blocks until n tokens are available, then
+    consumes them. Method ``try_acquire(n=1)`` returns True/False
+    immediately.
+  * ``rate_limit(rate, burst)`` — a decorator that throttles a
+    function with a per-decorator ``TokenBucket``.
+
+Tests cover both steady-state (rate caps long runs) and burst (the
+first ``burst`` calls are immediate).
+"""
+
+import time
+
+
+class TokenBucket:
+    def __init__(self, rate, burst):
+        raise NotImplementedError
+
+    def acquire(self, n=1):
+        raise NotImplementedError
+
+    def try_acquire(self, n=1):
+        raise NotImplementedError
+
+
+def rate_limit(rate, burst):
+    """Return a decorator that wraps a function with a TokenBucket
+    of (rate, burst). The wrapped function blocks via ``acquire(1)``
+    before invoking the underlying callable.
+    """
+    raise NotImplementedError

--- a/docs/benchmarks/fixtures/feature-rate-limit/test_limiter.py
+++ b/docs/benchmarks/fixtures/feature-rate-limit/test_limiter.py
@@ -1,0 +1,50 @@
+"""Acceptance tests for feature-rate-limit.
+
+Passes when ``TokenBucket`` and the ``rate_limit`` decorator behave
+correctly in the burst and steady-state regimes.
+"""
+
+import time
+
+from limiter import TokenBucket, rate_limit
+
+
+def test_burst_capacity_is_immediate():
+    bucket = TokenBucket(rate=1, burst=5)
+    started = time.perf_counter()
+    for _ in range(5):
+        assert bucket.try_acquire(1) is True
+    elapsed = time.perf_counter() - started
+    assert elapsed < 0.05
+
+
+def test_try_acquire_returns_false_when_empty():
+    bucket = TokenBucket(rate=0.5, burst=2)
+    assert bucket.try_acquire(1) is True
+    assert bucket.try_acquire(1) is True
+    assert bucket.try_acquire(1) is False
+
+
+def test_acquire_blocks_until_refill():
+    bucket = TokenBucket(rate=20, burst=1)
+    bucket.acquire(1)  # drain
+    started = time.perf_counter()
+    bucket.acquire(1)  # must wait ~1/20 = 50ms
+    elapsed = time.perf_counter() - started
+    assert 0.03 <= elapsed < 0.5
+
+
+def test_rate_limit_decorator_caps_throughput():
+    calls = []
+
+    @rate_limit(rate=20, burst=1)
+    def f():
+        calls.append(time.perf_counter())
+
+    started = time.perf_counter()
+    for _ in range(4):
+        f()
+    elapsed = time.perf_counter() - started
+    # 4 calls at 20/s with burst=1 must take at least ~3*(1/20) = 150ms.
+    assert elapsed >= 0.12
+    assert len(calls) == 4

--- a/docs/benchmarks/fixtures/refactor-config-merge/README.md
+++ b/docs/benchmarks/fixtures/refactor-config-merge/README.md
@@ -1,0 +1,10 @@
+# refactor-config-merge (benchmark fixture)
+
+Replace the nested if-cascade in ``merged_config`` with a single
+``deep_merge`` helper that recursively merges two dicts (the right
+operand wins). ``merged_config`` should reduce to chained
+``deep_merge`` calls while preserving precedence:
+
+    defaults < user < override
+
+Acceptance command: ``pytest -q``.

--- a/docs/benchmarks/fixtures/refactor-config-merge/config.py
+++ b/docs/benchmarks/fixtures/refactor-config-merge/config.py
@@ -1,0 +1,64 @@
+"""Three-layer config merge implemented as a nested if-cascade.
+
+The agent is asked to replace the cascade with a single ``deep_merge``
+helper while preserving precedence semantics:
+
+  defaults < user < override
+
+i.e. ``override`` wins, then ``user``, then ``defaults``. Nested dicts
+merge recursively; non-dict leaves replace.
+"""
+
+
+def merged_config(defaults, user, override):
+    out = {}
+    for k in set(defaults) | set(user) | set(override):
+        if k in override:
+            if (
+                isinstance(override[k], dict)
+                and k in user
+                and isinstance(user[k], dict)
+                and k in defaults
+                and isinstance(defaults[k], dict)
+            ):
+                inner = {}
+                for ik in set(defaults[k]) | set(user[k]) | set(override[k]):
+                    if ik in override[k]:
+                        inner[ik] = override[k][ik]
+                    elif ik in user[k]:
+                        inner[ik] = user[k][ik]
+                    else:
+                        inner[ik] = defaults[k][ik]
+                out[k] = inner
+            elif (
+                isinstance(override[k], dict)
+                and k in user
+                and isinstance(user[k], dict)
+            ):
+                inner = {}
+                for ik in set(user[k]) | set(override[k]):
+                    if ik in override[k]:
+                        inner[ik] = override[k][ik]
+                    else:
+                        inner[ik] = user[k][ik]
+                out[k] = inner
+            else:
+                out[k] = override[k]
+        elif k in user:
+            if (
+                isinstance(user[k], dict)
+                and k in defaults
+                and isinstance(defaults[k], dict)
+            ):
+                inner = {}
+                for ik in set(defaults[k]) | set(user[k]):
+                    if ik in user[k]:
+                        inner[ik] = user[k][ik]
+                    else:
+                        inner[ik] = defaults[k][ik]
+                out[k] = inner
+            else:
+                out[k] = user[k]
+        else:
+            out[k] = defaults[k]
+    return out

--- a/docs/benchmarks/fixtures/refactor-config-merge/test_config.py
+++ b/docs/benchmarks/fixtures/refactor-config-merge/test_config.py
@@ -1,0 +1,51 @@
+"""Acceptance tests for refactor-config-merge.
+
+Passes when:
+  1. ``merged_config`` still preserves precedence (override > user > defaults).
+  2. A ``deep_merge`` helper exists at module level.
+  3. ``merged_config`` delegates to ``deep_merge`` (we monkey-patch and
+     observe the substitution flows through).
+"""
+
+import config
+from config import merged_config
+
+
+def test_override_wins():
+    out = merged_config({"a": 1}, {"a": 2}, {"a": 3})
+    assert out == {"a": 3}
+
+
+def test_user_beats_defaults_when_override_absent():
+    out = merged_config({"a": 1}, {"a": 2}, {})
+    assert out == {"a": 2}
+
+
+def test_defaults_used_when_others_absent():
+    out = merged_config({"a": 1}, {}, {})
+    assert out == {"a": 1}
+
+
+def test_nested_dict_merge():
+    out = merged_config(
+        {"db": {"host": "localhost", "port": 5432, "user": "x"}},
+        {"db": {"port": 6000}},
+        {"db": {"user": "admin"}},
+    )
+    assert out == {"db": {"host": "localhost", "port": 6000, "user": "admin"}}
+
+
+def test_non_dict_leaf_replaces_dict():
+    out = merged_config({"x": {"a": 1}}, {}, {"x": "scalar"})
+    assert out == {"x": "scalar"}
+
+
+def test_deep_merge_helper_exists():
+    assert hasattr(config, "deep_merge"), "deep_merge helper not introduced"
+
+
+def test_merged_config_delegates_to_deep_merge(monkeypatch):
+    sentinel = {"sentinel": True}
+    monkeypatch.setattr(config, "deep_merge", lambda *args, **kwargs: sentinel)
+    out = merged_config({"a": 1}, {"b": 2}, {"c": 3})
+    assert out == sentinel

--- a/docs/benchmarks/fixtures/refactor-cron/README.md
+++ b/docs/benchmarks/fixtures/refactor-cron/README.md
@@ -1,0 +1,9 @@
+# refactor-cron (benchmark fixture)
+
+Extract the cron-string parsing inlined inside ``schedule_job`` into a
+top-level helper ``parse_cron(spec: str) -> CronSpec``. ``schedule_job``
+must keep the same external behavior and now call ``parse_cron``.
+
+The agent's prompt is the ``description`` field for ``refactor-cron``
+in ``docs/benchmarks/tasks.json``. The acceptance command is
+``pytest -q``.

--- a/docs/benchmarks/fixtures/refactor-cron/scheduler.py
+++ b/docs/benchmarks/fixtures/refactor-cron/scheduler.py
@@ -1,0 +1,41 @@
+"""Job scheduler with inline cron-string parsing.
+
+The agent is asked to extract the cron-parsing logic into a top-level
+helper named ``parse_cron(spec: str) -> CronSpec`` without changing the
+external behavior of ``schedule_job``.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class CronSpec:
+    minute: int
+    hour: int
+    day: int
+    month: int
+    weekday: int
+
+
+def schedule_job(name, cron_spec):
+    parts = cron_spec.strip().split()
+    if len(parts) != 5:
+        raise ValueError("cron spec must have 5 fields")
+    fields = []
+    for p in parts:
+        if p == "*":
+            fields.append(-1)
+        else:
+            try:
+                fields.append(int(p))
+            except ValueError as e:
+                raise ValueError(f"unsupported cron field {p!r}") from e
+    minute, hour, day, month, weekday = fields
+    return {
+        "name": name,
+        "minute": minute,
+        "hour": hour,
+        "day": day,
+        "month": month,
+        "weekday": weekday,
+    }

--- a/docs/benchmarks/fixtures/refactor-cron/test_scheduler.py
+++ b/docs/benchmarks/fixtures/refactor-cron/test_scheduler.py
@@ -1,0 +1,57 @@
+"""Acceptance tests for refactor-cron.
+
+The fixture passes when:
+  1. ``schedule_job`` still produces the same dict shape it did before.
+  2. A top-level ``parse_cron(spec) -> CronSpec`` helper exists and
+     returns a populated ``CronSpec``.
+  3. ``schedule_job`` actually delegates to ``parse_cron`` (i.e. the
+     parsing is not duplicated). We assert this by monkey-patching
+     ``parse_cron`` and observing that ``schedule_job`` picks up the
+     replacement.
+"""
+
+import inspect
+
+import pytest
+
+import scheduler
+from scheduler import CronSpec, schedule_job
+
+
+def test_schedule_job_shape_preserved():
+    job = schedule_job("nightly", "0 3 * * *")
+    assert job["name"] == "nightly"
+    assert job["minute"] == 0
+    assert job["hour"] == 3
+    assert job["day"] == -1
+    assert job["month"] == -1
+    assert job["weekday"] == -1
+
+
+def test_invalid_field_count_raises():
+    with pytest.raises(ValueError):
+        schedule_job("bad", "0 3 *")
+
+
+def test_parse_cron_helper_exists():
+    assert hasattr(scheduler, "parse_cron"), "parse_cron helper not extracted"
+    sig = inspect.signature(scheduler.parse_cron)
+    assert len(sig.parameters) == 1
+
+
+def test_parse_cron_returns_cronspec():
+    spec = scheduler.parse_cron("15 4 1 * *")
+    assert isinstance(spec, CronSpec)
+    assert spec.minute == 15
+    assert spec.hour == 4
+    assert spec.day == 1
+    assert spec.month == -1
+    assert spec.weekday == -1
+
+
+def test_schedule_job_delegates_to_parse_cron(monkeypatch):
+    sentinel = CronSpec(minute=99, hour=99, day=99, month=99, weekday=99)
+    monkeypatch.setattr(scheduler, "parse_cron", lambda spec: sentinel)
+    job = scheduler.schedule_job("x", "0 0 0 0 0")
+    assert job["minute"] == 99
+    assert job["hour"] == 99

--- a/docs/benchmarks/fixtures/refactor-csv-rows/README.md
+++ b/docs/benchmarks/fixtures/refactor-csv-rows/README.md
@@ -1,0 +1,9 @@
+# refactor-csv-rows (benchmark fixture)
+
+Switch ``report.py`` from positional row indexing (``row[0]``,
+``row[1]``, ``row[2]``) to a namedtuple or dataclass keyed by header
+name. ``read_report`` should return rows whose fields are reachable by
+name (``row.user``, ``row.amount``); ``total_amount`` and
+``unique_users`` must keep working.
+
+Acceptance command: ``pytest -q``.

--- a/docs/benchmarks/fixtures/refactor-csv-rows/report.py
+++ b/docs/benchmarks/fixtures/refactor-csv-rows/report.py
@@ -1,0 +1,31 @@
+"""CSV report reader using positional indexing.
+
+The agent is asked to switch from ``row[0]`` / ``row[1]`` index access
+to a namedtuple (or dataclass) keyed by header name. ``read_report``
+must keep its return type — a list of ``Row`` (namedtuple) — and the
+two accessor functions ``total_amount`` and ``unique_users`` must
+continue to work over an iterable of rows.
+"""
+
+import csv
+
+
+def read_report(path):
+    rows = []
+    with open(path, newline="", encoding="utf-8") as f:
+        reader = csv.reader(f)
+        next(reader)  # skip header
+        for row in reader:
+            rows.append(row)
+    return rows
+
+
+def total_amount(rows):
+    total = 0.0
+    for row in rows:
+        total += float(row[2])
+    return total
+
+
+def unique_users(rows):
+    return {row[1] for row in rows}

--- a/docs/benchmarks/fixtures/refactor-csv-rows/test_report.py
+++ b/docs/benchmarks/fixtures/refactor-csv-rows/test_report.py
@@ -1,0 +1,54 @@
+"""Acceptance tests for refactor-csv-rows.
+
+Passes when the readers stop accessing CSV cells by integer index and
+expose them by header name. We assert this both behaviorally (a Row's
+fields are reachable by attribute or key) and structurally (no
+``row[0]`` / ``row[1]`` / ``row[2]`` substrings remain in report.py).
+"""
+
+import re
+from pathlib import Path
+
+import report
+from report import read_report, total_amount, unique_users
+
+
+SAMPLE_CSV = (
+    "id,user,amount\n"
+    "1,alice,12.50\n"
+    "2,bob,7.00\n"
+    "3,alice,3.25\n"
+)
+
+
+def _write_sample(tmp_path):
+    p = tmp_path / "sample.csv"
+    p.write_text(SAMPLE_CSV, encoding="utf-8")
+    return p
+
+
+def test_total_amount(tmp_path):
+    rows = read_report(_write_sample(tmp_path))
+    assert abs(total_amount(rows) - 22.75) < 1e-9
+
+
+def test_unique_users(tmp_path):
+    rows = read_report(_write_sample(tmp_path))
+    assert unique_users(rows) == {"alice", "bob"}
+
+
+def test_rows_expose_named_fields(tmp_path):
+    rows = read_report(_write_sample(tmp_path))
+    assert rows, "read_report returned no rows"
+    first = rows[0]
+    user = getattr(first, "user", None)
+    if user is None and hasattr(first, "__getitem__") and not isinstance(first, list):
+        user = first["user"]
+    assert user == "alice"
+
+
+def test_no_positional_indexing_left_in_source():
+    src = Path(report.__file__).read_text(encoding="utf-8")
+    assert not re.search(r"row\[\s*[0-9]+\s*\]", src), (
+        "report.py still indexes rows by integer position"
+    )

--- a/docs/benchmarks/fixtures/refactor-rename/README.md
+++ b/docs/benchmarks/fixtures/refactor-rename/README.md
@@ -1,0 +1,8 @@
+# refactor-rename (benchmark fixture)
+
+Rename the ambiguously-named module-level function ``do`` and the
+local variable ``tmp`` to descriptive names. The public API
+``mean_variance(values) -> (mean, variance)`` must keep its name and
+behavior.
+
+Acceptance command: ``pytest -q``.

--- a/docs/benchmarks/fixtures/refactor-rename/stats.py
+++ b/docs/benchmarks/fixtures/refactor-rename/stats.py
@@ -1,0 +1,28 @@
+"""Statistics module with two ambiguously-named identifiers.
+
+The agent is asked to rename:
+  * the function ``do`` (which computes a running mean+variance update)
+  * the local variable ``tmp`` (which holds the current delta)
+
+to something descriptive, without altering the public API:
+``mean_variance(values) -> (mean, variance)``.
+"""
+
+
+def do(state, x):
+    n, mean, m2 = state
+    n += 1
+    tmp = x - mean
+    mean += tmp / n
+    m2 += tmp * (x - mean)
+    return n, mean, m2
+
+
+def mean_variance(values):
+    state = (0, 0.0, 0.0)
+    for v in values:
+        state = do(state, v)
+    n, mean, m2 = state
+    if n < 2:
+        return mean, 0.0
+    return mean, m2 / (n - 1)

--- a/docs/benchmarks/fixtures/refactor-rename/test_stats.py
+++ b/docs/benchmarks/fixtures/refactor-rename/test_stats.py
@@ -1,0 +1,34 @@
+"""Acceptance tests for refactor-rename.
+
+Passes when:
+  1. ``mean_variance`` (the public API) still returns correct values.
+  2. The ambiguous identifier ``do`` is no longer a module-level name.
+  3. The literal token ``tmp`` does not appear in the source.
+"""
+
+import re
+from pathlib import Path
+
+import stats
+from stats import mean_variance
+
+
+def test_mean_variance_basic():
+    mean, variance = mean_variance([2, 4, 4, 4, 5, 5, 7, 9])
+    assert abs(mean - 5.0) < 1e-9
+    assert abs(variance - 32.0 / 7.0) < 1e-9
+
+
+def test_mean_variance_singleton():
+    mean, variance = mean_variance([42])
+    assert mean == 42
+    assert variance == 0.0
+
+
+def test_do_renamed():
+    assert not hasattr(stats, "do"), "module-level 'do' was not renamed"
+
+
+def test_tmp_renamed():
+    src = Path(stats.__file__).read_text(encoding="utf-8")
+    assert not re.search(r"\btmp\b", src), "local 'tmp' was not renamed"

--- a/docs/benchmarks/tasks.json
+++ b/docs/benchmarks/tasks.json
@@ -1,0 +1,114 @@
+{
+  "schema_version": 1,
+  "description": "Issue #8 coding-quality regression task pack. 10 representative tasks (4 refactor, 3 bugfix, 3 feature) used to detect whether enabling any verse-driven mode degrades coding quality vs baseline. Each task ships a small Python fixture under docs/benchmarks/fixtures/<id>/ and is graded by running pytest against the fixture's tests.",
+  "modes": [
+    {
+      "id": "baseline",
+      "description": "scripture-mcp uninstalled; bare agent invocation. The reference distribution."
+    },
+    {
+      "id": "preview-only",
+      "description": "Claude /bible (or Codex [[bible:...]]) marker is typed but the user does NOT confirm injection. Tests that the preview path itself does not influence the model."
+    },
+    {
+      "id": "inject-once",
+      "description": "Marker is typed AND confirmed; the verse envelope is in turn N's model_call input. The user's coding instruction follows in the same turn."
+    },
+    {
+      "id": "recap-only",
+      "description": "Mode B recap is enabled, but no markers are typed. Recap fires after the run; the agent never sees a verse during the coding work."
+    }
+  ],
+  "tasks": [
+    {
+      "id": "refactor-cron",
+      "type": "refactor",
+      "name": "Extract cron-string parsing into a helper",
+      "description": "The fixture's scheduler.py inlines cron-string parsing inside schedule_job. Extract a parse_cron(spec: str) -> CronSpec helper without changing schedule_job's external behavior.",
+      "fixture_dir": "fixtures/refactor-cron",
+      "acceptance": "pytest -q",
+      "lines_of_code": 45
+    },
+    {
+      "id": "refactor-config-merge",
+      "type": "refactor",
+      "name": "Replace nested if-cascade with dict-merge",
+      "description": "config.py merges three config layers via nested if-cascade. Replace with a single deep_merge helper while preserving precedence semantics.",
+      "fixture_dir": "fixtures/refactor-config-merge",
+      "acceptance": "pytest -q",
+      "lines_of_code": 60
+    },
+    {
+      "id": "refactor-csv-rows",
+      "type": "refactor",
+      "name": "Switch CSV reader from index-based to namedtuple-based",
+      "description": "report.py reads CSV rows as lists and accesses fields by integer index. Switch to a namedtuple/dataclass keyed by header name.",
+      "fixture_dir": "fixtures/refactor-csv-rows",
+      "acceptance": "pytest -q",
+      "lines_of_code": 50
+    },
+    {
+      "id": "refactor-rename",
+      "type": "refactor",
+      "name": "Rename ambiguous identifier across module",
+      "description": "stats.py has a function named `do` and a variable named `tmp` whose roles are non-obvious. Rename to descriptive names without altering external API.",
+      "fixture_dir": "fixtures/refactor-rename",
+      "acceptance": "pytest -q",
+      "lines_of_code": 35
+    },
+    {
+      "id": "bugfix-off-by-one",
+      "type": "bugfix",
+      "name": "Off-by-one in window aggregation",
+      "description": "windows.py's rolling_sum returns one fewer window than expected for every window size — its loop's upper bound is off by one. Find and fix it.",
+      "fixture_dir": "fixtures/bugfix-off-by-one",
+      "acceptance": "pytest -q",
+      "lines_of_code": 25
+    },
+    {
+      "id": "bugfix-utf8-truncate",
+      "type": "bugfix",
+      "name": "UTF-8 truncation cuts mid-codepoint",
+      "description": "truncate.py's truncate_bytes splits multi-byte UTF-8 sequences, producing invalid output. Fix without regressing the byte-budget contract.",
+      "fixture_dir": "fixtures/bugfix-utf8-truncate",
+      "acceptance": "pytest -q",
+      "lines_of_code": 30
+    },
+    {
+      "id": "bugfix-race-counter",
+      "type": "bugfix",
+      "name": "Counter increments are lost under concurrency",
+      "description": "counter.py's increment is called from multiple threads but uses non-atomic += on an int. Make it thread-safe; the lock-free fast-path is acceptable if proven correct.",
+      "fixture_dir": "fixtures/bugfix-race-counter",
+      "acceptance": "pytest -q",
+      "lines_of_code": 40
+    },
+    {
+      "id": "feature-rate-limit",
+      "type": "feature",
+      "name": "Add a token-bucket rate limiter",
+      "description": "Add a TokenBucket class to limiter.py that enforces a configurable rate and burst; the existing function rate_limit(f, rate, burst) wires it as a decorator. Tests cover steady-state and burst.",
+      "fixture_dir": "fixtures/feature-rate-limit",
+      "acceptance": "pytest -q",
+      "lines_of_code": 55
+    },
+    {
+      "id": "feature-flatten-json",
+      "type": "feature",
+      "name": "Add a flatten_json(obj, sep='.') -> dict helper",
+      "description": "Add flatten_json to flatten.py: nested dicts become dotted keys; lists become bracketed indices; scalars pass through. Tests cover four nesting shapes.",
+      "fixture_dir": "fixtures/feature-flatten-json",
+      "acceptance": "pytest -q",
+      "lines_of_code": 50
+    },
+    {
+      "id": "feature-cli-flag",
+      "type": "feature",
+      "name": "Add --json output mode to existing CLI",
+      "description": "tool.py prints a human-readable summary today. Add an opt-in --json flag that emits the same data as a single JSON object on stdout. Existing default output must be unchanged.",
+      "fixture_dir": "fixtures/feature-cli-flag",
+      "acceptance": "pytest -q",
+      "lines_of_code": 65
+    }
+  ]
+}

--- a/docs/benchmarks/v0.1.md
+++ b/docs/benchmarks/v0.1.md
@@ -1,0 +1,55 @@
+# Coding-quality benchmark — v0.1 (template)
+
+This file is the publication template the issue #8 acceptance gate
+fills in for each release. Real numbers will be appended once the
+benchmark runner has been driven against a live API key.
+
+Adapter: **claude** + **codex** (run separately, table per adapter)
+Modes: `baseline`, `preview-only`, `inject-once`, `recap-only`
+
+Acceptance: per-task `pytest -q` against the fixture's tests. A run is
+graded **pass** iff the acceptance suite exits 0. The issue #8
+acceptance gate is: **no mode regresses success rate by more than 5
+percentage points vs baseline.**
+
+## How to (re)generate this file
+
+```bash
+ANTHROPIC_API_KEY=... \
+BENCH_AGENT_CMD='./scripts/bench_dispatch_claude.sh' \
+python3 scripts/bench_runner.py \
+  --adapter=claude \
+  --out=docs/benchmarks/v0.1.md
+```
+
+`bench_dispatch_claude.sh` is the per-adapter shim that translates the
+runner's BENCH_* env vars into a real Claude Code (or Codex) headless
+invocation. The shim is intentionally not part of this repo because it
+depends on the user's local agent install path; an example is in the
+PR that lands the actual benchmark numbers.
+
+## Per-mode success rate (placeholder)
+
+| mode | success | n |
+|---|---|---|
+| baseline | _tbd_ | 10 |
+| preview-only | _tbd_ | 10 |
+| inject-once | _tbd_ | 10 |
+| recap-only | _tbd_ | 10 |
+
+## Per-task results (placeholder)
+
+| task | mode | success | input tok | output tok | p50 ms |
+|---|---|---|---|---|---|
+| _populated by scripts/bench_runner.py_ | | | | | |
+
+## Notes for the first run
+
+- Recommend pinning the Claude/Codex model+version in the dispatch
+  shim and recording it in the report header — coding-quality
+  numbers are model-version-sensitive.
+- Run each (task, mode, adapter) at least 3× and report the median,
+  so a single noisy completion does not flip a row.
+- `inject-once` uses `Matthew 6:26` (KJV) as the canonical prompt
+  verse — short, doctrinally neutral, and present in the bundled
+  pack. Pinning the verse makes runs comparable.

--- a/internal/lifecycle/bench_pack_test.go
+++ b/internal/lifecycle/bench_pack_test.go
@@ -1,0 +1,151 @@
+package lifecycle
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// taskPack mirrors docs/benchmarks/tasks.json. Only the fields the
+// regression test checks are decoded.
+type taskPack struct {
+	SchemaVersion int `json:"schema_version"`
+	Modes         []struct {
+		ID          string `json:"id"`
+		Description string `json:"description"`
+	} `json:"modes"`
+	Tasks []struct {
+		ID          string `json:"id"`
+		Type        string `json:"type"`
+		Name        string `json:"name"`
+		Description string `json:"description"`
+		FixtureDir  string `json:"fixture_dir"`
+		Acceptance  string `json:"acceptance"`
+		LinesOfCode int    `json:"lines_of_code"`
+	} `json:"tasks"`
+}
+
+// TestBenchPackStructure locks in the contract docs/benchmarks/tasks.json
+// must satisfy. It is the regression net for the issue #8 acceptance
+// criterion "Task pack of 10 representative coding tasks (mix of
+// refactor / bug fix / new feature)" and "Four modes: baseline,
+// preview-only, inject-once, recap-only".
+//
+// The test is deliberately structural — it does NOT try to dispatch
+// the agent or grade tasks (that requires a live API key and lives in
+// scripts/bench_runner.py). What it locks in is: the pack exists, has
+// the right shape, the right counts, the modes the runner expects,
+// and one fixture vendored as a working template.
+func TestBenchPackStructure(t *testing.T) {
+	path := repoFile(t, "docs/benchmarks/tasks.json")
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var pack taskPack
+	if err := json.Unmarshal(body, &pack); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	if pack.SchemaVersion != 1 {
+		t.Errorf("schema_version = %d, want 1", pack.SchemaVersion)
+	}
+	if got := len(pack.Tasks); got != 10 {
+		t.Errorf("want 10 tasks, got %d", got)
+	}
+	wantModes := map[string]bool{
+		"baseline": false, "preview-only": false,
+		"inject-once": false, "recap-only": false,
+	}
+	for _, m := range pack.Modes {
+		if _, ok := wantModes[m.ID]; ok {
+			wantModes[m.ID] = true
+		}
+		if m.Description == "" {
+			t.Errorf("mode %s missing description", m.ID)
+		}
+	}
+	for id, seen := range wantModes {
+		if !seen {
+			t.Errorf("missing required mode: %s", id)
+		}
+	}
+
+	wantTypes := map[string]int{"refactor": 0, "bugfix": 0, "feature": 0}
+	seenIDs := map[string]bool{}
+	for _, task := range pack.Tasks {
+		if task.ID == "" {
+			t.Errorf("task missing id: %+v", task)
+			continue
+		}
+		if seenIDs[task.ID] {
+			t.Errorf("duplicate task id: %s", task.ID)
+		}
+		seenIDs[task.ID] = true
+		if _, ok := wantTypes[task.Type]; !ok {
+			t.Errorf("task %s: type %q not in {refactor,bugfix,feature}", task.ID, task.Type)
+		}
+		wantTypes[task.Type]++
+		if task.Description == "" {
+			t.Errorf("task %s: empty description", task.ID)
+		}
+		if task.FixtureDir == "" {
+			t.Errorf("task %s: empty fixture_dir", task.ID)
+		}
+		if task.Acceptance == "" {
+			t.Errorf("task %s: empty acceptance command", task.ID)
+		}
+	}
+	for typ, n := range wantTypes {
+		if n == 0 {
+			t.Errorf("task pack must contain at least one %s task", typ)
+		}
+	}
+}
+
+// TestBenchTemplateFixtureExists checks that the one vendored fixture
+// referenced by the pack is actually present and has the expected
+// shape (source file + test file). This locks in the convention so
+// future fixture additions follow it.
+func TestBenchTemplateFixtureExists(t *testing.T) {
+	dir := repoFile(t, "docs/benchmarks/fixtures/bugfix-off-by-one")
+	for _, f := range []string{"windows.py", "test_windows.py", "README.md"} {
+		path := filepath.Join(dir, f)
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("template fixture missing %s: %v", f, err)
+		}
+	}
+}
+
+// TestBenchReportTemplateExists confirms the publication template
+// exists so the issue #8 release artifact has a known location.
+func TestBenchReportTemplateExists(t *testing.T) {
+	path := repoFile(t, "docs/benchmarks/v0.1.md")
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("report template missing: %v", err)
+	}
+}
+
+// repoFile resolves a repo-root-relative path. Tests run with cwd =
+// the package directory, so we walk up to find the go.mod.
+func repoFile(t *testing.T, rel string) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	dir := filepath.Dir(file)
+	for i := 0; i < 6; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return filepath.Join(dir, rel)
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatalf("could not find go.mod walking up from %s", file)
+	return ""
+}

--- a/internal/lifecycle/bench_pack_test.go
+++ b/internal/lifecycle/bench_pack_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -104,16 +105,56 @@ func TestBenchPackStructure(t *testing.T) {
 	}
 }
 
-// TestBenchTemplateFixtureExists checks that the one vendored fixture
-// referenced by the pack is actually present and has the expected
-// shape (source file + test file). This locks in the convention so
-// future fixture additions follow it.
-func TestBenchTemplateFixtureExists(t *testing.T) {
-	dir := repoFile(t, "docs/benchmarks/fixtures/bugfix-off-by-one")
-	for _, f := range []string{"windows.py", "test_windows.py", "README.md"} {
-		path := filepath.Join(dir, f)
-		if _, err := os.Stat(path); err != nil {
-			t.Errorf("template fixture missing %s: %v", f, err)
+// TestBenchFixturesPresent confirms every fixture referenced by
+// docs/benchmarks/tasks.json is actually vendored under
+// docs/benchmarks/fixtures/<id>/ with at least the three required
+// files: a README, a source file, and a pytest acceptance file.
+//
+// This is the regression net for the issue #8 acceptance criterion
+// "task pack of 10 representative coding tasks". Adding a task to
+// tasks.json without vendoring the fixture (or vice versa) fails CI.
+func TestBenchFixturesPresent(t *testing.T) {
+	path := repoFile(t, "docs/benchmarks/tasks.json")
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var pack taskPack
+	if err := json.Unmarshal(body, &pack); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	for _, task := range pack.Tasks {
+		dir := repoFile(t, filepath.Join("docs/benchmarks", task.FixtureDir))
+		if _, err := os.Stat(dir); err != nil {
+			t.Errorf("task %s: fixture dir missing: %v", task.ID, err)
+			continue
+		}
+		readme := filepath.Join(dir, "README.md")
+		if _, err := os.Stat(readme); err != nil {
+			t.Errorf("task %s: README.md missing", task.ID)
+		}
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			t.Errorf("task %s: read dir: %v", task.ID, err)
+			continue
+		}
+		var hasSource, hasTest bool
+		for _, e := range entries {
+			name := e.Name()
+			if !strings.HasSuffix(name, ".py") {
+				continue
+			}
+			if strings.HasPrefix(name, "test_") {
+				hasTest = true
+			} else {
+				hasSource = true
+			}
+		}
+		if !hasSource {
+			t.Errorf("task %s: no non-test .py source file in fixture", task.ID)
+		}
+		if !hasTest {
+			t.Errorf("task %s: no test_*.py acceptance file in fixture", task.ID)
 		}
 	}
 }

--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -1,0 +1,295 @@
+// Package lifecycle simulates the per-turn prompt-passing behavior of a
+// coding agent (Claude Code or Codex) wired to scripture-mcp's hooks, so
+// that the v0.1 injection-lifecycle invariant is testable in CI without a
+// live model.
+//
+// The invariant under test (issue #8):
+//
+//  1. Turn N: a marker in the user prompt → the verse appears in turn N's
+//     model_call input via the hook envelope.
+//  2. Turn N+1: no marker → the verse is GONE. It is not in turn N+1's
+//     model_call input.
+//  3. Compaction-resistant: this remains true across an arbitrarily long
+//     run of follow-up turns (the harness exercises 30+).
+//  4. Mode B recap stdout flows to a separate "terminal" channel that is
+//     never fed back as input to subsequent turns.
+//
+// The harness drives the same scripture-mcp surface the real agents drive
+// (lookup-from-prompt and recap), in-process via internal/cli, so the
+// invariant follows from the binary's behavior rather than from a mock.
+//
+// What we do NOT simulate: the model itself. We assert on what enters the
+// model_call input — the leftmost surface where the lifecycle invariant
+// must hold. Whether the model can quote a verse it was given, and
+// whether it cannot quote one it was not given, are LLM-side properties
+// that the optional online check in TestLifecycleEnd2EndOnline covers
+// when ANTHROPIC_API_KEY is set.
+package lifecycle
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/MiaoDX/verse-driven/internal/cli"
+)
+
+// Adapter selects which marker syntax a simulated turn uses in its user
+// prompt. Both adapters share the same lookup-from-prompt binary, so the
+// only difference is how the user expresses the marker.
+type Adapter int
+
+const (
+	// Claude: leading slash form, e.g. "/bible John 3:16 do the thing".
+	AdapterClaude Adapter = iota
+	// Codex: inline brackets form, e.g. "do the thing [[bible:John 3:16]]".
+	AdapterCodex
+)
+
+func (a Adapter) String() string {
+	switch a {
+	case AdapterClaude:
+		return "claude"
+	case AdapterCodex:
+		return "codex"
+	}
+	return "unknown"
+}
+
+// Turn captures everything that happens on one simulated user turn:
+// the user-typed prompt, the model_call input the agent would assemble
+// after running its hooks, and any text the Stop-hook recap printed to
+// the user's terminal channel after the turn ended.
+//
+// ModelInput is the channel the lifecycle invariant cares about — it is
+// what the model sees on this turn. RecapTerminal is the channel that
+// must NEVER appear in any subsequent turn's ModelInput.
+type Turn struct {
+	UserPrompt    string
+	ModelInput    string
+	RecapTerminal string
+}
+
+// Simulator threads a sequence of Turns. Stateless across turns by
+// design: each turn's ModelInput is computed solely from that turn's
+// UserPrompt plus any envelope the hook produces — no carry-over from
+// prior turns. This is the architectural property that makes the
+// "verse is gone next turn" invariant true; the simulator makes it
+// observable.
+type Simulator struct {
+	Adapter   Adapter
+	transcript []Turn
+	// recapSeed makes the optional Mode B recap deterministic for tests.
+	// Zero leaves the recap CLI to its time-based default.
+	recapSeed int64
+	// recapTradition optionally constrains which tradition recap pulls
+	// from — useful for tests that want a known-content recap.
+	recapTradition string
+}
+
+// New returns a fresh Simulator wired to the given adapter.
+func New(adapter Adapter) *Simulator {
+	return &Simulator{Adapter: adapter}
+}
+
+// SetRecapSeed makes recap deterministic for tests; pair with
+// SetRecapTradition to fully pin the recap output.
+func (s *Simulator) SetRecapSeed(seed int64)       { s.recapSeed = seed }
+func (s *Simulator) SetRecapTradition(t string)    { s.recapTradition = t }
+
+// Transcript returns the full slice of recorded turns.
+func (s *Simulator) Transcript() []Turn { return s.transcript }
+
+// Last returns the most recent recorded turn.
+func (s *Simulator) Last() Turn {
+	if len(s.transcript) == 0 {
+		return Turn{}
+	}
+	return s.transcript[len(s.transcript)-1]
+}
+
+// RunTurn drives one turn through the hook surface. It runs the same
+// `lookup-from-prompt` command the real adapter would invoke, captures
+// any envelope the hook emits, builds the model_call input as
+// "prompt + envelope" (the field semantics of UserPromptExpansion /
+// UserPromptSubmit's additionalContext), and appends a Turn to the
+// transcript.
+//
+// withRecap=true also fires the Stop-hook recap after the turn ends and
+// records its output in RecapTerminal — the user-terminal-only channel
+// the invariant says must never enter a model_call input.
+func (s *Simulator) RunTurn(prompt string, withRecap bool) Turn {
+	envelope := s.invokeLookupFromPrompt(prompt)
+	model := prompt
+	if envelope != "" {
+		// additionalContext is concatenated with the user prompt; the
+		// exact glue character doesn't matter for the invariant — what
+		// matters is whether the verse text is present.
+		model = prompt + "\n\n" + envelope
+	}
+	turn := Turn{UserPrompt: prompt, ModelInput: model}
+	if withRecap {
+		turn.RecapTerminal = s.invokeRecap()
+	}
+	s.transcript = append(s.transcript, turn)
+	return turn
+}
+
+// invokeLookupFromPrompt calls the real CLI subcommand in-process. The
+// hook's contract is to emit a JSON object {"additionalContext": "..."}
+// on stdout when a marker is present, and exit 0 with no output
+// otherwise.
+func (s *Simulator) invokeLookupFromPrompt(prompt string) string {
+	var stdout, stderr bytes.Buffer
+	streams := cli.Streams{
+		In:  strings.NewReader(prompt),
+		Out: &stdout,
+		Err: &stderr,
+	}
+	code := cli.Run("lookup-from-prompt", nil, streams)
+	if code != 0 {
+		// A failing hook still must not break the turn; the binary
+		// soft-fails by spec. Treat as no envelope.
+		return ""
+	}
+	if stdout.Len() == 0 {
+		return ""
+	}
+	var resp struct {
+		AdditionalContext string `json:"additionalContext"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &resp); err != nil {
+		return ""
+	}
+	return resp.AdditionalContext
+}
+
+// invokeRecap calls `recap` and captures its terminal-only output.
+func (s *Simulator) invokeRecap() string {
+	var stdout, stderr bytes.Buffer
+	args := []string{"--terminal"}
+	if s.recapTradition != "" {
+		args = append(args, "--tradition="+s.recapTradition)
+	}
+	if s.recapSeed != 0 {
+		args = append(args, fmt.Sprintf("--seed=%d", s.recapSeed))
+	}
+	streams := cli.Streams{
+		In:  strings.NewReader(""),
+		Out: &stdout,
+		Err: &stderr,
+	}
+	if cli.Run("recap", args, streams) != 0 {
+		return ""
+	}
+	return stdout.String()
+}
+
+// Leak describes a residual fragment found in a turn's ModelInput where
+// the lifecycle invariant says it should not be. Returned by the assert
+// helpers so test failures can name exactly which turn leaked and what
+// content was found.
+type Leak struct {
+	TurnIndex int
+	Fragment  string
+	Found     string // a window around the leak for human inspection
+}
+
+func (l Leak) String() string {
+	return fmt.Sprintf("turn %d leaked %q\n  context: %s",
+		l.TurnIndex, l.Fragment, l.Found)
+}
+
+// FindLeaks scans every turn at index >= startIdx and reports every
+// occurrence of fragment in that turn's ModelInput. Used to assert that
+// a verse injected on turn N does not survive past turn N.
+func (s *Simulator) FindLeaks(startIdx int, fragment string) []Leak {
+	if fragment == "" {
+		return nil
+	}
+	var out []Leak
+	for i := startIdx; i < len(s.transcript); i++ {
+		mi := s.transcript[i].ModelInput
+		idx := strings.Index(mi, fragment)
+		if idx < 0 {
+			continue
+		}
+		out = append(out, Leak{
+			TurnIndex: i,
+			Fragment:  fragment,
+			Found:     contextWindow(mi, idx, len(fragment)),
+		})
+	}
+	return out
+}
+
+// FindRecapLeaks scans every turn's ModelInput for any non-empty recap
+// text recorded in any prior turn. The architectural guarantee that
+// recap stdout never enters a future model_call input is the core of
+// Mode B's safety.
+func (s *Simulator) FindRecapLeaks() []Leak {
+	var leaks []Leak
+	for i, t := range s.transcript {
+		recap := strings.TrimSpace(t.RecapTerminal)
+		if recap == "" {
+			continue
+		}
+		// Use the verse-body line of the recap (line 3 onward, after
+		// the header and blank line). This avoids false positives on
+		// the "📖" emoji or attribution that could legitimately appear
+		// in unrelated context.
+		body := recapVerseBody(recap)
+		if body == "" {
+			continue
+		}
+		for j := i + 1; j < len(s.transcript); j++ {
+			mi := s.transcript[j].ModelInput
+			idx := strings.Index(mi, body)
+			if idx < 0 {
+				continue
+			}
+			leaks = append(leaks, Leak{
+				TurnIndex: j,
+				Fragment:  body,
+				Found:     contextWindow(mi, idx, len(body)),
+			})
+		}
+	}
+	return leaks
+}
+
+// recapVerseBody pulls just the verse-body of a recap printout: skip
+// the header line ("📖 ..."), the optional attribution line, and the
+// blank line, and return the rest. This is the substring whose
+// presence in a future model_call input would constitute a leak.
+func recapVerseBody(recap string) string {
+	lines := strings.Split(recap, "\n")
+	// Drop leading non-empty header lines until we hit a blank.
+	var i int
+	for i = 0; i < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) == "" {
+			i++
+			break
+		}
+	}
+	body := strings.TrimSpace(strings.Join(lines[i:], "\n"))
+	return body
+}
+
+// contextWindow returns a few chars on each side of the leak position
+// for human-readable failure messages.
+func contextWindow(s string, start, length int) string {
+	const pad = 32
+	from := start - pad
+	if from < 0 {
+		from = 0
+	}
+	to := start + length + pad
+	if to > len(s) {
+		to = len(s)
+	}
+	w := s[from:to]
+	w = strings.ReplaceAll(w, "\n", "⏎")
+	return "..." + w + "..."
+}

--- a/internal/lifecycle/lifecycle_test.go
+++ b/internal/lifecycle/lifecycle_test.go
@@ -1,0 +1,267 @@
+package lifecycle
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/MiaoDX/verse-driven/internal/packs"
+	"github.com/MiaoDX/verse-driven/internal/resolver"
+)
+
+// fetchVerseText resolves a reference and returns its body. Tests use
+// this to derive the leak-fragment string from the bundled pack rather
+// than hard-coding scripture text in the test source.
+func fetchVerseText(t *testing.T, ref string) string {
+	t.Helper()
+	r, err := resolver.Resolve(ref)
+	if err != nil {
+		t.Fatalf("resolve %q: %v", ref, err)
+	}
+	v, err := packs.LookupReference(r)
+	if err != nil {
+		t.Fatalf("lookup %q: %v", ref, err)
+	}
+	if v.Text == "" {
+		t.Fatalf("verse %q has empty text", ref)
+	}
+	return v.Text
+}
+
+// followUpPrompt returns a per-turn no-marker prompt. Variation matters:
+// we want to be sure the absence of leakage isn't accidentally caused by
+// the follow-up prompt happening to overlap a marker pattern.
+func followUpPrompt(i int) string {
+	templates := []string{
+		"keep going on the helper",
+		"now run the tests",
+		"refactor that function please",
+		"add a docstring to the new method",
+		"rename the variable to be clearer",
+		"explain why this branch is taken",
+		"check the imports for unused ones",
+		"split the long function into two",
+		"add a unit test for the edge case",
+		"fix the staticcheck warning",
+	}
+	return fmt.Sprintf("turn %d: %s", i, templates[i%len(templates)])
+}
+
+// TestLifecycleClaude_TurnNVisibleNPlus1Gone is the make-or-break
+// invariant from issue #8 for the Claude adapter. Turn 0 injects via
+// the slash marker; turn 1 has no marker; we assert the verse body is
+// present in turn 0's ModelInput and absent from turn 1's.
+func TestLifecycleClaude_TurnNVisibleNPlus1Gone(t *testing.T) {
+	verseText := fetchVerseText(t, "John 3:16")
+	sim := New(AdapterClaude)
+
+	turn0 := sim.RunTurn("/bible John 3:16 Refactor the cron-string scheduler.", false)
+	if !strings.Contains(turn0.ModelInput, verseText) {
+		t.Fatalf("turn 0: verse must be in model input but is not\n%s", turn0.ModelInput)
+	}
+	if !strings.Contains(turn0.ModelInput, "<scripture_card>") {
+		t.Fatalf("turn 0: envelope tags missing")
+	}
+
+	turn1 := sim.RunTurn(followUpPrompt(1), false)
+	if leaks := sim.FindLeaks(1, verseText); len(leaks) > 0 {
+		t.Fatalf("turn 1 leaked verse text:\n%s", leaks[0])
+	}
+	if strings.Contains(turn1.ModelInput, "<scripture_card>") {
+		t.Fatalf("turn 1: envelope tags must not appear")
+	}
+}
+
+// TestLifecycleCodex_TurnNVisibleNPlus1Gone — same invariant for the
+// Codex inline-marker syntax.
+func TestLifecycleCodex_TurnNVisibleNPlus1Gone(t *testing.T) {
+	verseText := fetchVerseText(t, "John 3:16")
+	sim := New(AdapterCodex)
+
+	turn0 := sim.RunTurn("Refactor the cron-string scheduler. [[bible:John 3:16]]", false)
+	if !strings.Contains(turn0.ModelInput, verseText) {
+		t.Fatalf("turn 0: verse must be in model input but is not")
+	}
+
+	sim.RunTurn(followUpPrompt(1), false)
+	if leaks := sim.FindLeaks(1, verseText); len(leaks) > 0 {
+		t.Fatalf("turn 1 leaked verse text:\n%s", leaks[0])
+	}
+}
+
+// TestLifecycleCompactionResistantClaude exercises the issue's stronger
+// claim: even after 30 follow-up turns, the verse from the first turn
+// is not recoverable via the model_call input. This is the
+// "compaction-resistant" property — it follows architecturally from the
+// stateless-per-turn hook design, but we verify it explicitly.
+func TestLifecycleCompactionResistantClaude(t *testing.T) {
+	verseText := fetchVerseText(t, "John 3:16")
+	sim := New(AdapterClaude)
+
+	sim.RunTurn("/bible John 3:16 Refactor X.", false)
+	const followUps = 30
+	for i := 1; i <= followUps; i++ {
+		sim.RunTurn(followUpPrompt(i), false)
+	}
+	if leaks := sim.FindLeaks(1, verseText); len(leaks) > 0 {
+		t.Fatalf("verse leaked across %d follow-up turns:\n%s", followUps, leaks[0])
+	}
+}
+
+func TestLifecycleCompactionResistantCodex(t *testing.T) {
+	verseText := fetchVerseText(t, "道德经 11")
+	sim := New(AdapterCodex)
+
+	sim.RunTurn("Refactor X. [[dao:11]]", false)
+	const followUps = 30
+	for i := 1; i <= followUps; i++ {
+		sim.RunTurn(followUpPrompt(i), false)
+	}
+	if leaks := sim.FindLeaks(1, verseText); len(leaks) > 0 {
+		t.Fatalf("verse leaked across %d follow-up turns:\n%s", followUps, leaks[0])
+	}
+}
+
+// TestRecapNeverEntersModelInput is the Mode B half of issue #8. After
+// every turn we fire the Stop hook (recap), and we assert that the
+// recap text never appears in any subsequent turn's ModelInput. The
+// architectural reason it doesn't: recap output goes to stdout (= the
+// user's terminal), not to additionalContext. The harness models that
+// channel separation explicitly via Turn.RecapTerminal.
+func TestRecapNeverEntersModelInputClaude(t *testing.T) {
+	sim := New(AdapterClaude)
+	sim.SetRecapSeed(42)
+	sim.SetRecapTradition("dao") // small pool, deterministic
+
+	const turns = 30
+	for i := 0; i < turns; i++ {
+		sim.RunTurn(followUpPrompt(i), true /*withRecap*/)
+	}
+	leaks := sim.FindRecapLeaks()
+	if len(leaks) > 0 {
+		t.Fatalf("recap leaked into a future model input: %s", leaks[0])
+	}
+	// Sanity: at least one turn must actually have produced a recap, or
+	// we'd be passing the test trivially.
+	any := false
+	for _, tn := range sim.Transcript() {
+		if strings.TrimSpace(tn.RecapTerminal) != "" {
+			any = true
+			break
+		}
+	}
+	if !any {
+		t.Fatalf("no recap output recorded across %d turns; cannot assert isolation", turns)
+	}
+}
+
+func TestRecapNeverEntersModelInputCodex(t *testing.T) {
+	sim := New(AdapterCodex)
+	sim.SetRecapSeed(7)
+	sim.SetRecapTradition("dao")
+
+	const turns = 30
+	for i := 0; i < turns; i++ {
+		sim.RunTurn(followUpPrompt(i), true)
+	}
+	if leaks := sim.FindRecapLeaks(); len(leaks) > 0 {
+		t.Fatalf("recap leaked into a future model input: %s", leaks[0])
+	}
+}
+
+// TestLeakFailureMessageNamesTurnAndContent verifies that when a leak
+// IS found, the harness's failure message identifies the turn index and
+// shows a context window — required by issue #8 ("On failure, prints
+// which turn leaked and what residual content was found").
+func TestLeakFailureMessageNamesTurnAndContent(t *testing.T) {
+	sim := New(AdapterClaude)
+	sim.RunTurn("/bible John 3:16 do X", false)
+	// Manually corrupt turn 1's model input to simulate a regression.
+	sim.transcript = append(sim.transcript, Turn{
+		UserPrompt: "follow up",
+		ModelInput: "follow up\nstray verse fragment: For God so loved",
+	})
+	leaks := sim.FindLeaks(1, "For God so loved")
+	if len(leaks) != 1 {
+		t.Fatalf("expected 1 leak, got %d", len(leaks))
+	}
+	msg := leaks[0].String()
+	if !strings.Contains(msg, "turn 1") {
+		t.Errorf("failure message must name the turn index; got: %s", msg)
+	}
+	if !strings.Contains(msg, "context:") {
+		t.Errorf("failure message must include a content window; got: %s", msg)
+	}
+}
+
+// TestEnvelopeIsolatedToInjectingTurn confirms that re-running
+// lookup-from-prompt on a turn-N+1 prompt that does not contain the
+// marker yields no envelope at all — the lifecycle invariant is a
+// straightforward consequence.
+func TestEnvelopeIsolatedToInjectingTurn(t *testing.T) {
+	sim := New(AdapterClaude)
+	sim.RunTurn("/bible John 3:16 do X", false)
+	turn1 := sim.RunTurn("just a regular follow-up", false)
+	if strings.Contains(turn1.ModelInput, "<scripture_card>") {
+		t.Errorf("turn 1 must have no envelope; got:\n%s", turn1.ModelInput)
+	}
+	if turn1.ModelInput != turn1.UserPrompt {
+		t.Errorf("turn 1 model input must equal the user prompt; got %q vs %q",
+			turn1.ModelInput, turn1.UserPrompt)
+	}
+}
+
+// TestSlashMarkerTraditions covers all four traditions for the Claude
+// slash-marker form. The lifecycle invariant must hold regardless of
+// which tradition is injected.
+func TestSlashMarkerTraditionsLifecycle(t *testing.T) {
+	cases := []struct {
+		marker string
+		ref    string
+	}{
+		{"/bible John 3:16", "John 3:16"},
+		{"/dao 11", "道德经 11"},
+		// sutra and quran ship api_only in v0.1, so the hook soft-fails
+		// to no-envelope; the lifecycle invariant is still preserved
+		// (no envelope = no leak possible) but there's nothing to leak.
+	}
+	for _, tc := range cases {
+		t.Run(tc.marker, func(t *testing.T) {
+			verseText := fetchVerseText(t, tc.ref)
+			sim := New(AdapterClaude)
+			turn0 := sim.RunTurn(tc.marker+" do the thing", false)
+			if !strings.Contains(turn0.ModelInput, verseText) {
+				t.Fatalf("turn 0: verse missing for %s", tc.marker)
+			}
+			sim.RunTurn("follow up no marker", false)
+			if leaks := sim.FindLeaks(1, verseText); len(leaks) > 0 {
+				t.Fatalf("%s leaked next turn:\n%s", tc.marker, leaks[0])
+			}
+		})
+	}
+}
+
+// TestRecapBodyExtractor verifies that recapVerseBody isolates the
+// verse text from the recap header so FindRecapLeaks doesn't generate
+// false positives on header glyphs.
+func TestRecapBodyExtractor(t *testing.T) {
+	sample := "📖 Some Reference\n(some attribution)\n\nthe actual body line"
+	body := recapVerseBody(sample)
+	if body != "the actual body line" {
+		t.Errorf("recapVerseBody = %q, want %q", body, "the actual body line")
+	}
+}
+
+// TestContextWindowTrimsToBounds is a small sanity check — the harness
+// must report leaks even when they sit at the start or end of a string
+// without panicking.
+func TestContextWindowTrimsToBounds(t *testing.T) {
+	w := contextWindow("hello world", 0, 5)
+	if !strings.Contains(w, "hello") {
+		t.Errorf("contextWindow at start dropped content: %q", w)
+	}
+	w = contextWindow("hello world", 6, 5)
+	if !strings.Contains(w, "world") {
+		t.Errorf("contextWindow at end dropped content: %q", w)
+	}
+}

--- a/scripts/bench_runner.py
+++ b/scripts/bench_runner.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""bench_runner.py — coding-quality benchmark runner for issue #8.
+
+Runs one or more tasks from docs/benchmarks/tasks.json against a coding
+agent across the four configured modes, records per-task metrics, and
+emits a Markdown report at docs/benchmarks/<date>.md.
+
+This script is the runner skeleton: it wires the task pack, the modes,
+the per-task fixture invocation, and the report rendering. The actual
+agent invocation is gated by environment so CI can validate the runner's
+own correctness without an API key, while a developer with a key can
+produce a real benchmark.
+
+Required env for a real run:
+  ANTHROPIC_API_KEY    — Claude side
+  OPENAI_API_KEY       — Codex side (optional; Codex runs are skipped
+                          if missing)
+
+Optional env:
+  BENCH_AGENT_CMD      — override how a task is dispatched. The
+                          default invokes the Claude or Codex CLI in
+                          headless mode against the task's fixture
+                          directory; setting this to "echo" turns the
+                          runner into a smoke test that still produces
+                          a (failing) report row.
+  BENCH_TASK_FILTER    — comma-separated task ids to include (default:
+                          all)
+  BENCH_MODES          — comma-separated mode ids (default:
+                          baseline,preview-only,inject-once,recap-only)
+  BENCH_OUT            — output report path (default: docs/benchmarks/
+                          today's date .md)
+
+Why a script and not a Go program: invoking external coding agents and
+their pytest acceptance suites is fundamentally a shell-orchestration
+task, and Python is the lingua franca of the agent CLIs we drive.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+from dataclasses import asdict, dataclass, field
+from datetime import date
+from pathlib import Path
+from typing import Optional
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TASKS_FILE = REPO_ROOT / "docs" / "benchmarks" / "tasks.json"
+DEFAULT_MODES = ("baseline", "preview-only", "inject-once", "recap-only")
+
+
+@dataclass
+class TaskResult:
+    task_id: str
+    mode: str
+    adapter: str
+    success: bool  # acceptance suite passed
+    input_tokens: Optional[int]  # None when the agent didn't report
+    output_tokens: Optional[int]
+    latency_p50_ms: Optional[float]
+    error: Optional[str] = None
+
+
+@dataclass
+class BenchSummary:
+    date: str
+    adapter: str
+    modes: list[str]
+    results: list[TaskResult] = field(default_factory=list)
+
+
+def load_tasks() -> dict:
+    if not TASKS_FILE.exists():
+        sys.exit(f"task pack not found at {TASKS_FILE}")
+    return json.loads(TASKS_FILE.read_text(encoding="utf-8"))
+
+
+def filter_tasks(pack: dict, allow: Optional[list[str]]) -> list[dict]:
+    if not allow:
+        return list(pack["tasks"])
+    by_id = {t["id"]: t for t in pack["tasks"]}
+    out = []
+    for tid in allow:
+        if tid not in by_id:
+            sys.exit(f"unknown task id in BENCH_TASK_FILTER: {tid}")
+        out.append(by_id[tid])
+    return out
+
+
+def acceptance(fixture_dir: Path, command: str) -> tuple[bool, str]:
+    """Run the per-task acceptance command in fixture_dir. Returns
+    (passed, captured_output). The command is shell-evaluated to keep
+    the per-task surface flexible (most tasks use ``pytest -q``).
+    """
+    if not fixture_dir.exists():
+        return False, f"fixture dir missing: {fixture_dir}"
+    try:
+        proc = subprocess.run(
+            command,
+            shell=True,
+            cwd=str(fixture_dir),
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+    except subprocess.TimeoutExpired as e:
+        return False, f"timeout: {e}"
+    out = (proc.stdout or "") + (proc.stderr or "")
+    return proc.returncode == 0, out
+
+
+def dispatch_agent(task: dict, mode: str, adapter: str, work_dir: Path) -> dict:
+    """Invoke the coding agent against work_dir. Returns a dict with
+    optional metric fields the agent emitted: input_tokens,
+    output_tokens, latency_p50_ms, error.
+
+    The default implementation expects the env-overridable
+    BENCH_AGENT_CMD to handle the actual invocation. The cmd receives
+    these env vars:
+
+      BENCH_TASK_ID
+      BENCH_MODE
+      BENCH_ADAPTER
+      BENCH_WORK_DIR    — the fixture directory the agent edits
+      BENCH_PROMPT      — the prompt template (with marker prefix per
+                          mode + adapter)
+
+    and is expected to emit a single JSON object on stdout with the
+    metric fields. If BENCH_AGENT_CMD is unset we record a skip — the
+    runner's own correctness can still be validated end-to-end via
+    BENCH_AGENT_CMD=echo (which yields a failing acceptance result and
+    a complete report row).
+    """
+    cmd = os.environ.get("BENCH_AGENT_CMD")
+    if not cmd:
+        return {"error": "BENCH_AGENT_CMD not set; skipping agent dispatch"}
+
+    prompt = build_prompt(task, mode, adapter)
+    env = os.environ.copy()
+    env.update(
+        {
+            "BENCH_TASK_ID": task["id"],
+            "BENCH_MODE": mode,
+            "BENCH_ADAPTER": adapter,
+            "BENCH_WORK_DIR": str(work_dir),
+            "BENCH_PROMPT": prompt,
+        }
+    )
+    started = time.perf_counter()
+    proc = subprocess.run(
+        cmd, shell=True, capture_output=True, text=True, env=env, timeout=300
+    )
+    elapsed_ms = (time.perf_counter() - started) * 1000.0
+    out: dict = {"latency_p50_ms": elapsed_ms}
+    if proc.returncode != 0:
+        out["error"] = f"agent exited {proc.returncode}: {proc.stderr.strip()}"
+        return out
+    try:
+        body = json.loads(proc.stdout.strip() or "{}")
+        for k in ("input_tokens", "output_tokens"):
+            if k in body:
+                out[k] = body[k]
+    except json.JSONDecodeError:
+        # Agent didn't emit JSON; we still recorded latency.
+        pass
+    return out
+
+
+def build_prompt(task: dict, mode: str, adapter: str) -> str:
+    """Return the user-facing prompt the agent sees, including the
+    marker prefix appropriate to the mode + adapter combination.
+    """
+    body = task["description"]
+    if mode == "inject-once" and adapter == "claude":
+        return f"/bible Matthew 6:26 {body}"
+    if mode == "inject-once" and adapter == "codex":
+        return f"{body} [[bible:Matthew 6:26]]"
+    if mode == "preview-only":
+        # The user types the marker but cancels; semantically the
+        # agent sees the same body as baseline. We document the typed
+        # marker in the prompt's comment for the report's prompt-log,
+        # but it is not actually injected.
+        return body
+    return body
+
+
+def run(adapter: str, modes: list[str], task_filter: Optional[list[str]]) -> BenchSummary:
+    pack = load_tasks()
+    tasks = filter_tasks(pack, task_filter)
+    summary = BenchSummary(date=str(date.today()), adapter=adapter, modes=modes)
+    for task in tasks:
+        for mode in modes:
+            fixture_src = TASKS_FILE.parent / task["fixture_dir"]
+            scratch = REPO_ROOT / ".bench-scratch" / f"{task['id']}__{mode}__{adapter}"
+            if scratch.exists():
+                shutil.rmtree(scratch)
+            scratch.parent.mkdir(parents=True, exist_ok=True)
+            if fixture_src.exists():
+                shutil.copytree(fixture_src, scratch)
+            else:
+                scratch.mkdir(parents=True)
+            metrics = dispatch_agent(task, mode, adapter, scratch)
+            passed, _ = acceptance(scratch, task["acceptance"])
+            summary.results.append(
+                TaskResult(
+                    task_id=task["id"],
+                    mode=mode,
+                    adapter=adapter,
+                    success=passed,
+                    input_tokens=metrics.get("input_tokens"),
+                    output_tokens=metrics.get("output_tokens"),
+                    latency_p50_ms=metrics.get("latency_p50_ms"),
+                    error=metrics.get("error"),
+                )
+            )
+    return summary
+
+
+def render_report(summary: BenchSummary) -> str:
+    lines: list[str] = []
+    lines.append(f"# Coding-quality benchmark — {summary.date}")
+    lines.append("")
+    lines.append(f"Adapter: **{summary.adapter}**  ")
+    lines.append(f"Modes: {', '.join(summary.modes)}")
+    lines.append("")
+    lines.append(
+        "Acceptance: per-task `pytest -q` against the fixture's tests. "
+        "A run is graded **pass** iff the acceptance suite exits 0. The "
+        "issue #8 acceptance gate is: no mode regresses success rate by "
+        "more than 5 percentage points vs baseline."
+    )
+    lines.append("")
+    lines.append("## Per-mode success rate")
+    by_mode: dict[str, list[TaskResult]] = {m: [] for m in summary.modes}
+    for r in summary.results:
+        by_mode[r.mode].append(r)
+    lines.append("| mode | success | n |")
+    lines.append("|---|---|---|")
+    for m in summary.modes:
+        rows = by_mode[m]
+        if not rows:
+            lines.append(f"| {m} | — | 0 |")
+            continue
+        passed = sum(1 for r in rows if r.success)
+        rate = passed / len(rows)
+        lines.append(f"| {m} | {rate:.0%} | {len(rows)} |")
+    lines.append("")
+    lines.append("## Per-task results")
+    lines.append("| task | mode | success | input tok | output tok | p50 ms | error |")
+    lines.append("|---|---|---|---|---|---|---|")
+    for r in summary.results:
+        lines.append(
+            f"| {r.task_id} | {r.mode} | "
+            f"{'✅' if r.success else '❌'} | "
+            f"{r.input_tokens if r.input_tokens is not None else '—'} | "
+            f"{r.output_tokens if r.output_tokens is not None else '—'} | "
+            f"{r.latency_p50_ms:.0f}" + (" | " if r.latency_p50_ms else " — | ")
+            + (r.error or "") + " |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--adapter", default="claude", choices=("claude", "codex"))
+    parser.add_argument(
+        "--modes",
+        default=os.environ.get("BENCH_MODES", ",".join(DEFAULT_MODES)),
+        help="comma-separated list of mode ids",
+    )
+    parser.add_argument(
+        "--tasks",
+        default=os.environ.get("BENCH_TASK_FILTER", ""),
+        help="comma-separated task ids (empty = all)",
+    )
+    parser.add_argument(
+        "--out",
+        default=os.environ.get(
+            "BENCH_OUT",
+            str(REPO_ROOT / "docs" / "benchmarks" / f"{date.today()}.md"),
+        ),
+    )
+    args = parser.parse_args()
+    modes = [m.strip() for m in args.modes.split(",") if m.strip()]
+    tasks = [t.strip() for t in args.tasks.split(",") if t.strip()] or None
+    summary = run(args.adapter, modes, tasks)
+    Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+    Path(args.out).write_text(render_report(summary), encoding="utf-8")
+    # Also drop a machine-readable version next to it for downstream
+    # diffing (regression gate computation lives in CI).
+    Path(args.out + ".json").write_text(
+        json.dumps(asdict(summary), indent=2), encoding="utf-8"
+    )
+    print(f"wrote {args.out}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Superseded by #20 (clean branch off `main`; the rebased history on `claude-issue-8` was tangled with the prior squash-merged PR #17).

---
_Generated by [Claude Code](https://claude.ai/code/)_