### PR TITLE
test(bench): vendor 9 remaining benchmark fixtures for issue #8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ bin/
 *.out
 .DS_Store
 .bench-scratch/
+__pycache__/
+*.pyc

--- a/docs/benchmarks/fixtures/bugfix-off-by-one/README.md
+++ b/docs/benchmarks/fixtures/bugfix-off-by-one/README.md
@@ -19,8 +19,5 @@ The agent's prompt for this task is the `description` field in
 copied) read-write before the run; tests run against the post-edit
 state.
 
-## Remaining fixtures
-
-The other nine fixtures referenced by `tasks.json` follow the same
-convention but are not yet vendored. Adding them is tracked as part
-of the remaining work for issue #8 — see the issue's checklist.
+All ten fixtures referenced by `tasks.json` follow this same
+convention; this directory is the original template.

--- a/docs/benchmarks/fixtures/bugfix-race-counter/README.md
+++ b/docs/benchmarks/fixtures/bugfix-race-counter/README.md
@@ -1,0 +1,12 @@
+# bugfix-race-counter (benchmark fixture)
+
+Make ``Counter`` thread-safe. Concurrent ``increment`` and ``add``
+calls from many threads must never lose updates. The public API
+(``Counter``, ``increment``, ``add``, ``value``) must not change.
+
+A ``threading.Lock`` around the read-modify-write is the canonical
+fix; alternative approaches (``threading.RLock``, atomic primitives
+from ``itertools.count`` semantics, etc.) are acceptable as long as
+the tests pass.
+
+Acceptance command: ``pytest -q``.

--- a/docs/benchmarks/fixtures/bugfix-race-counter/counter.py
+++ b/docs/benchmarks/fixtures/bugfix-race-counter/counter.py
@@ -1,0 +1,38 @@
+"""Thread-shared counter with a concurrency bug.
+
+The current ``Counter.add`` does an explicit read-modify-write with a
+small ``time.sleep(0)`` between the read and the write — a classic
+non-atomic pattern that races even under the CPython GIL because the
+sleep is a guaranteed thread-yield point. Many concurrent ``add``
+calls will therefore lose updates.
+
+The agent must make the counter thread-safe (e.g. with a
+``threading.Lock`` around the read-modify-write) without changing the
+public API.
+
+Public API to preserve:
+
+  Counter()             - construct a new counter at zero
+  Counter().increment() - add one
+  Counter().add(n)      - add n
+  Counter().value       - read the current count
+"""
+
+import time
+
+
+class Counter:
+    def __init__(self):
+        self._n = 0
+
+    def increment(self):
+        self.add(1)
+
+    def add(self, n):
+        cur = self._n
+        time.sleep(0)  # force a GIL release between read and write
+        self._n = cur + n
+
+    @property
+    def value(self):
+        return self._n

--- a/docs/benchmarks/fixtures/bugfix-race-counter/test_counter.py
+++ b/docs/benchmarks/fixtures/bugfix-race-counter/test_counter.py
@@ -1,0 +1,57 @@
+"""Acceptance tests for bugfix-race-counter.
+
+Passes when concurrent increments from many threads land the right
+total. The single-threaded contract still holds.
+"""
+
+import threading
+
+from counter import Counter
+
+
+def test_single_threaded_increment():
+    c = Counter()
+    for _ in range(100):
+        c.increment()
+    assert c.value == 100
+
+
+def test_single_threaded_add():
+    c = Counter()
+    c.add(7)
+    c.add(3)
+    assert c.value == 10
+
+
+def test_concurrent_increment_no_lost_updates():
+    c = Counter()
+    n_threads = 16
+    per_thread = 5_000
+
+    def worker():
+        for _ in range(per_thread):
+            c.increment()
+
+    threads = [threading.Thread(target=worker) for _ in range(n_threads)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert c.value == n_threads * per_thread
+
+
+def test_concurrent_add_no_lost_updates():
+    c = Counter()
+    n_threads = 8
+    per_thread = 1_000
+
+    def worker():
+        for _ in range(per_thread):
+            c.add(3)
+
+    threads = [threading.Thread(target=worker) for _ in range(n_threads)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert c.value == n_threads * per_thread * 3

--- a/docs/benchmarks/fixtures/bugfix-utf8-truncate/README.md
+++ b/docs/benchmarks/fixtures/bugfix-utf8-truncate/README.md
@@ -1,0 +1,10 @@
+# bugfix-utf8-truncate (benchmark fixture)
+
+Fix ``truncate_bytes`` so it never returns bytes that split a UTF-8
+codepoint mid-sequence. The output must:
+
+  * have length ``<= n``,
+  * decode cleanly as UTF-8,
+  * be the longest valid prefix of the input that fits.
+
+Acceptance command: ``pytest -q``.

--- a/docs/benchmarks/fixtures/bugfix-utf8-truncate/test_truncate.py
+++ b/docs/benchmarks/fixtures/bugfix-utf8-truncate/test_truncate.py
@@ -1,0 +1,45 @@
+"""Acceptance tests for bugfix-utf8-truncate.
+
+Passes when ``truncate_bytes`` returns valid UTF-8 of length <= n that
+is the longest valid prefix of the input fitting in n bytes.
+"""
+
+import pytest
+
+from truncate import truncate_bytes
+
+
+def test_ascii_unchanged_when_budget_sufficient():
+    assert truncate_bytes("hello", 10) == b"hello"
+
+
+def test_ascii_clipped_at_byte_budget():
+    assert truncate_bytes("hello", 3) == b"hel"
+
+
+def test_multibyte_does_not_split_codepoint():
+    # "你" encodes to 3 bytes in UTF-8.
+    out = truncate_bytes("你好", 4)
+    assert len(out) <= 4
+    out.decode("utf-8")  # must not raise
+    assert out == "你".encode("utf-8")
+
+
+def test_emoji_does_not_split_codepoint():
+    # Smiling face emoji is 4 bytes in UTF-8.
+    out = truncate_bytes("ab😀cd", 4)
+    out.decode("utf-8")
+    assert out == b"ab"
+
+
+def test_zero_budget_returns_empty():
+    assert truncate_bytes("hello", 0) == b""
+
+
+def test_negative_budget_raises():
+    with pytest.raises(ValueError):
+        truncate_bytes("hi", -1)
+
+
+def test_full_string_when_budget_huge():
+    assert truncate_bytes("héllo", 100) == "héllo".encode("utf-8")

--- a/docs/benchmarks/fixtures/bugfix-utf8-truncate/truncate.py
+++ b/docs/benchmarks/fixtures/bugfix-utf8-truncate/truncate.py
@@ -1,0 +1,19 @@
+"""Truncate a string so its UTF-8 encoding fits a byte budget.
+
+There is a bug: the current implementation slices the encoded bytes at
+``n`` directly, which can land in the middle of a multi-byte UTF-8
+sequence and produce invalid UTF-8 (or, when decoded with errors set,
+a "replacement-character" suffix).
+
+The agent must fix ``truncate_bytes`` so the returned bytes:
+  * have length ``<= n``,
+  * decode cleanly as UTF-8,
+  * are the longest valid prefix of the input that fits.
+"""
+
+
+def truncate_bytes(s: str, n: int) -> bytes:
+    if n < 0:
+        raise ValueError("n must be >= 0")
+    encoded = s.encode("utf-8")
+    return encoded[:n]

--- a/docs/benchmarks/fixtures/feature-cli-flag/README.md
+++ b/docs/benchmarks/fixtures/feature-cli-flag/README.md
@@ -1,0 +1,10 @@
+# feature-cli-flag (benchmark fixture)
+
+Add an opt-in ``--json`` flag to ``tool.py`` that emits the same
+summary as a single JSON object on stdout. The default human-readable
+output must be unchanged.
+
+Add a ``render_json(summary) -> str`` helper that mirrors
+``render_text``.
+
+Acceptance command: ``pytest -q``.

--- a/docs/benchmarks/fixtures/feature-cli-flag/test_tool.py
+++ b/docs/benchmarks/fixtures/feature-cli-flag/test_tool.py
@@ -1,0 +1,40 @@
+"""Acceptance tests for feature-cli-flag.
+
+Passes when:
+  1. The default output (no --json) is unchanged.
+  2. ``--json`` emits a single JSON object with ``total``, ``count``,
+     ``top`` fields and nothing extra to stdout.
+  3. A ``render_json(summary) -> str`` helper exists.
+"""
+
+import json
+
+import tool
+from tool import main, render_text, summarize
+
+
+def test_summarize():
+    summary = summarize([("a", 1), ("b", 5), ("c", 2)])
+    assert summary == {"total": 8, "count": 3, "top": "b"}
+
+
+def test_default_output_unchanged(capsys):
+    rc = main(["apples=3", "bananas=7"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert out == render_text(summarize([("apples", 3), ("bananas", 7)]))
+
+
+def test_json_flag_emits_single_object(capsys):
+    rc = main(["--json", "apples=3", "bananas=7"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    body = json.loads(out)
+    assert body == {"total": 10, "count": 2, "top": "bananas"}
+
+
+def test_render_json_helper_exists():
+    assert hasattr(tool, "render_json"), "render_json helper not added"
+    summary = summarize([("a", 1)])
+    body = json.loads(tool.render_json(summary))
+    assert body == summary

--- a/docs/benchmarks/fixtures/feature-cli-flag/tool.py
+++ b/docs/benchmarks/fixtures/feature-cli-flag/tool.py
@@ -1,0 +1,63 @@
+"""A small CLI that summarizes a list of (name, count) pairs.
+
+Today it prints a human-readable summary. The agent is asked to add an
+opt-in ``--json`` flag that emits the same data as a single JSON
+object on stdout, while keeping the default human-readable output
+exactly as it is today.
+
+The summary is computed by ``summarize(items)`` and rendered for
+humans by ``render_text(summary)``. Add a ``render_json(summary)``
+that returns a JSON string with the same fields.
+
+Public functions to keep:
+  summarize(items) -> dict
+  render_text(summary) -> str
+  main(argv) -> int           # writes to stdout, returns exit code
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+
+def summarize(items):
+    total = sum(c for _, c in items)
+    top = max(items, key=lambda x: x[1])[0] if items else None
+    return {
+        "total": total,
+        "count": len(items),
+        "top": top,
+    }
+
+
+def render_text(summary):
+    return (
+        f"items: {summary['count']}\n"
+        f"total: {summary['total']}\n"
+        f"top: {summary['top']}\n"
+    )
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="summarize (name,count) pairs")
+    parser.add_argument(
+        "pairs",
+        nargs="*",
+        help="name=count tokens, e.g. apples=3 bananas=7",
+    )
+    args = parser.parse_args(argv)
+    items = []
+    for tok in args.pairs:
+        if "=" not in tok:
+            print(f"bad pair: {tok}", file=sys.stderr)
+            return 2
+        name, count = tok.split("=", 1)
+        items.append((name, int(count)))
+    summary = summarize(items)
+    sys.stdout.write(render_text(summary))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/benchmarks/fixtures/feature-flatten-json/README.md
+++ b/docs/benchmarks/fixtures/feature-flatten-json/README.md
@@ -1,0 +1,7 @@
+# feature-flatten-json (benchmark fixture)
+
+Implement ``flatten_json(obj, sep='.') -> dict``: nested dicts become
+dotted keys; lists become bracketed indices (``xs[0]``); scalars pass
+through. Non-dict top-level argument raises ``TypeError``.
+
+Acceptance command: ``pytest -q``.

--- a/docs/benchmarks/fixtures/feature-flatten-json/flatten.py
+++ b/docs/benchmarks/fixtures/feature-flatten-json/flatten.py
@@ -1,0 +1,22 @@
+"""flatten_json: turn nested JSON-shaped data into a flat dict.
+
+The agent is asked to implement ``flatten_json(obj, sep='.') -> dict``:
+
+  * Nested dicts: keys are joined with ``sep``.
+  * Lists: indices appear as ``[i]`` segments (no separator before
+    the bracket).
+  * Scalars (str, int, float, bool, None) are leaves.
+  * The top-level argument must be a dict; raise ``TypeError`` for
+    other shapes.
+
+Examples:
+
+    flatten_json({"a": {"b": 1}})           -> {"a.b": 1}
+    flatten_json({"xs": [10, 20]})          -> {"xs[0]": 10, "xs[1]": 20}
+    flatten_json({"a": {"b": [{"c": 1}]}})  -> {"a.b[0].c": 1}
+    flatten_json({}, sep='/')               -> {}
+"""
+
+
+def flatten_json(obj, sep="."):
+    raise NotImplementedError

--- a/docs/benchmarks/fixtures/feature-flatten-json/test_flatten.py
+++ b/docs/benchmarks/fixtures/feature-flatten-json/test_flatten.py
@@ -1,0 +1,42 @@
+"""Acceptance tests for feature-flatten-json. Four nesting shapes
+plus error cases.
+"""
+
+import pytest
+
+from flatten import flatten_json
+
+
+def test_flat_dict_passes_through():
+    assert flatten_json({"a": 1, "b": 2}) == {"a": 1, "b": 2}
+
+
+def test_nested_dicts_dotted():
+    assert flatten_json({"a": {"b": {"c": 9}}}) == {"a.b.c": 9}
+
+
+def test_list_uses_bracket_indices():
+    out = flatten_json({"xs": [10, 20, 30]})
+    assert out == {"xs[0]": 10, "xs[1]": 20, "xs[2]": 30}
+
+
+def test_mixed_dict_and_list():
+    out = flatten_json({"a": {"b": [{"c": 1}, {"d": 2}]}})
+    assert out == {"a.b[0].c": 1, "a.b[1].d": 2}
+
+
+def test_custom_separator():
+    assert flatten_json({"a": {"b": 1}}, sep="/") == {"a/b": 1}
+
+
+def test_empty_dict_yields_empty():
+    assert flatten_json({}) == {}
+
+
+def test_scalar_top_level_raises():
+    with pytest.raises(TypeError):
+        flatten_json(5)
+
+
+def test_none_value_preserved():
+    assert flatten_json({"a": None}) == {"a": None}

--- a/docs/benchmarks/fixtures/feature-rate-limit/README.md
+++ b/docs/benchmarks/fixtures/feature-rate-limit/README.md
@@ -1,0 +1,9 @@
+# feature-rate-limit (benchmark fixture)
+
+Implement ``TokenBucket(rate, burst)`` and a ``rate_limit(rate, burst)``
+decorator in ``limiter.py``. The bucket refills at ``rate`` tokens per
+second with capacity ``burst``; ``acquire(n)`` blocks, ``try_acquire(n)``
+returns immediately. The decorator wraps a function so each call
+``acquire(1)`` from a per-decorator bucket.
+
+Acceptance command: ``pytest -q``.

--- a/docs/benchmarks/fixtures/feature-rate-limit/limiter.py
+++ b/docs/benchmarks/fixtures/feature-rate-limit/limiter.py
@@ -1,0 +1,36 @@
+"""Token-bucket rate limiter — implementation TODO.
+
+The agent is asked to implement:
+
+  * ``TokenBucket(rate, burst)`` — a token bucket that refills at
+    ``rate`` tokens per second with capacity ``burst``. Method
+    ``acquire(n=1)`` blocks until n tokens are available, then
+    consumes them. Method ``try_acquire(n=1)`` returns True/False
+    immediately.
+  * ``rate_limit(rate, burst)`` — a decorator that throttles a
+    function with a per-decorator ``TokenBucket``.
+
+Tests cover both steady-state (rate caps long runs) and burst (the
+first ``burst`` calls are immediate).
+"""
+
+import time
+
+
+class TokenBucket:
+    def __init__(self, rate, burst):
+        raise NotImplementedError
+
+    def acquire(self, n=1):
+        raise NotImplementedError
+
+    def try_acquire(self, n=1):
+        raise NotImplementedError
+
+
+def rate_limit(rate, burst):
+    """Return a decorator that wraps a function with a TokenBucket
+    of (rate, burst). The wrapped function blocks via ``acquire(1)``
+    before invoking the underlying callable.
+    """
+    raise NotImplementedError

--- a/docs/benchmarks/fixtures/feature-rate-limit/test_limiter.py
+++ b/docs/benchmarks/fixtures/feature-rate-limit/test_limiter.py
@@ -1,0 +1,50 @@
+"""Acceptance tests for feature-rate-limit.
+
+Passes when ``TokenBucket`` and the ``rate_limit`` decorator behave
+correctly in the burst and steady-state regimes.
+"""
+
+import time
+
+from limiter import TokenBucket, rate_limit
+
+
+def test_burst_capacity_is_immediate():
+    bucket = TokenBucket(rate=1, burst=5)
+    started = time.perf_counter()
+    for _ in range(5):
+        assert bucket.try_acquire(1) is True
+    elapsed = time.perf_counter() - started
+    assert elapsed < 0.05
+
+
+def test_try_acquire_returns_false_when_empty():
+    bucket = TokenBucket(rate=0.5, burst=2)
+    assert bucket.try_acquire(1) is True
+    assert bucket.try_acquire(1) is True
+    assert bucket.try_acquire(1) is False
+
+
+def test_acquire_blocks_until_refill():
+    bucket = TokenBucket(rate=20, burst=1)
+    bucket.acquire(1)  # drain
+    started = time.perf_counter()
+    bucket.acquire(1)  # must wait ~1/20 = 50ms
+    elapsed = time.perf_counter() - started
+    assert 0.03 <= elapsed < 0.5
+
+
+def test_rate_limit_decorator_caps_throughput():
+    calls = []
+
+    @rate_limit(rate=20, burst=1)
+    def f():
+        calls.append(time.perf_counter())
+
+    started = time.perf_counter()
+    for _ in range(4):
+        f()
+    elapsed = time.perf_counter() - started
+    # 4 calls at 20/s with burst=1 must take at least ~3*(1/20) = 150ms.
+    assert elapsed >= 0.12
+    assert len(calls) == 4

--- a/docs/benchmarks/fixtures/refactor-config-merge/README.md
+++ b/docs/benchmarks/fixtures/refactor-config-merge/README.md
@@ -1,0 +1,10 @@
+# refactor-config-merge (benchmark fixture)
+
+Replace the nested if-cascade in ``merged_config`` with a single
+``deep_merge`` helper that recursively merges two dicts (the right
+operand wins). ``merged_config`` should reduce to chained
+``deep_merge`` calls while preserving precedence:
+
+    defaults < user < override
+
+Acceptance command: ``pytest -q``.

--- a/docs/benchmarks/fixtures/refactor-config-merge/config.py
+++ b/docs/benchmarks/fixtures/refactor-config-merge/config.py
@@ -1,0 +1,64 @@
+"""Three-layer config merge implemented as a nested if-cascade.
+
+The agent is asked to replace the cascade with a single ``deep_merge``
+helper while preserving precedence semantics:
+
+  defaults < user < override
+
+i.e. ``override`` wins, then ``user``, then ``defaults``. Nested dicts
+merge recursively; non-dict leaves replace.
+"""
+
+
+def merged_config(defaults, user, override):
+    out = {}
+    for k in set(defaults) | set(user) | set(override):
+        if k in override:
+            if (
+                isinstance(override[k], dict)
+                and k in user
+                and isinstance(user[k], dict)
+                and k in defaults
+                and isinstance(defaults[k], dict)
+            ):
+                inner = {}
+                for ik in set(defaults[k]) | set(user[k]) | set(override[k]):
+                    if ik in override[k]:
+                        inner[ik] = override[k][ik]
+                    elif ik in user[k]:
+                        inner[ik] = user[k][ik]
+                    else:
+                        inner[ik] = defaults[k][ik]
+                out[k] = inner
+            elif (
+                isinstance(override[k], dict)
+                and k in user
+                and isinstance(user[k], dict)
+            ):
+                inner = {}
+                for ik in set(user[k]) | set(override[k]):
+                    if ik in override[k]:
+                        inner[ik] = override[k][ik]
+                    else:
+                        inner[ik] = user[k][ik]
+                out[k] = inner
+            else:
+                out[k] = override[k]
+        elif k in user:
+            if (
+                isinstance(user[k], dict)
+                and k in defaults
+                and isinstance(defaults[k], dict)
+            ):
+                inner = {}
+                for ik in set(defaults[k]) | set(user[k]):
+                    if ik in user[k]:
+                        inner[ik] = user[k][ik]
+                    else:
+                        inner[ik] = defaults[k][ik]
+                out[k] = inner
+            else:
+                out[k] = user[k]
+        else:
+            out[k] = defaults[k]
+    return out

--- a/docs/benchmarks/fixtures/refactor-config-merge/test_config.py
+++ b/docs/benchmarks/fixtures/refactor-config-merge/test_config.py
@@ -1,0 +1,51 @@
+"""Acceptance tests for refactor-config-merge.
+
+Passes when:
+  1. ``merged_config`` still preserves precedence (override > user > defaults).
+  2. A ``deep_merge`` helper exists at module level.
+  3. ``merged_config`` delegates to ``deep_merge`` (we monkey-patch and
+     observe the substitution flows through).
+"""
+
+import config
+from config import merged_config
+
+
+def test_override_wins():
+    out = merged_config({"a": 1}, {"a": 2}, {"a": 3})
+    assert out == {"a": 3}
+
+
+def test_user_beats_defaults_when_override_absent():
+    out = merged_config({"a": 1}, {"a": 2}, {})
+    assert out == {"a": 2}
+
+
+def test_defaults_used_when_others_absent():
+    out = merged_config({"a": 1}, {}, {})
+    assert out == {"a": 1}
+
+
+def test_nested_dict_merge():
+    out = merged_config(
+        {"db": {"host": "localhost", "port": 5432, "user": "x"}},
+        {"db": {"port": 6000}},
+        {"db": {"user": "admin"}},
+    )
+    assert out == {"db": {"host": "localhost", "port": 6000, "user": "admin"}}
+
+
+def test_non_dict_leaf_replaces_dict():
+    out = merged_config({"x": {"a": 1}}, {}, {"x": "scalar"})
+    assert out == {"x": "scalar"}
+
+
+def test_deep_merge_helper_exists():
+    assert hasattr(config, "deep_merge"), "deep_merge helper not introduced"
+
+
+def test_merged_config_delegates_to_deep_merge(monkeypatch):
+    sentinel = {"sentinel": True}
+    monkeypatch.setattr(config, "deep_merge", lambda *args, **kwargs: sentinel)
+    out = merged_config({"a": 1}, {"b": 2}, {"c": 3})
+    assert out == sentinel

--- a/docs/benchmarks/fixtures/refactor-cron/README.md
+++ b/docs/benchmarks/fixtures/refactor-cron/README.md
@@ -1,0 +1,9 @@
+# refactor-cron (benchmark fixture)
+
+Extract the cron-string parsing inlined inside ``schedule_job`` into a
+top-level helper ``parse_cron(spec: str) -> CronSpec``. ``schedule_job``
+must keep the same external behavior and now call ``parse_cron``.
+
+The agent's prompt is the ``description`` field for ``refactor-cron``
+in ``docs/benchmarks/tasks.json``. The acceptance command is
+``pytest -q``.

--- a/docs/benchmarks/fixtures/refactor-cron/scheduler.py
+++ b/docs/benchmarks/fixtures/refactor-cron/scheduler.py
@@ -1,0 +1,41 @@
+"""Job scheduler with inline cron-string parsing.
+
+The agent is asked to extract the cron-parsing logic into a top-level
+helper named ``parse_cron(spec: str) -> CronSpec`` without changing the
+external behavior of ``schedule_job``.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class CronSpec:
+    minute: int
+    hour: int
+    day: int
+    month: int
+    weekday: int
+
+
+def schedule_job(name, cron_spec):
+    parts = cron_spec.strip().split()
+    if len(parts) != 5:
+        raise ValueError("cron spec must have 5 fields")
+    fields = []
+    for p in parts:
+        if p == "*":
+            fields.append(-1)
+        else:
+            try:
+                fields.append(int(p))
+            except ValueError as e:
+                raise ValueError(f"unsupported cron field {p!r}") from e
+    minute, hour, day, month, weekday = fields
+    return {
+        "name": name,
+        "minute": minute,
+        "hour": hour,
+        "day": day,
+        "month": month,
+        "weekday": weekday,
+    }

--- a/docs/benchmarks/fixtures/refactor-cron/test_scheduler.py
+++ b/docs/benchmarks/fixtures/refactor-cron/test_scheduler.py
@@ -1,0 +1,57 @@
+"""Acceptance tests for refactor-cron.
+
+The fixture passes when:
+  1. ``schedule_job`` still produces the same dict shape it did before.
+  2. A top-level ``parse_cron(spec) -> CronSpec`` helper exists and
+     returns a populated ``CronSpec``.
+  3. ``schedule_job`` actually delegates to ``parse_cron`` (i.e. the
+     parsing is not duplicated). We assert this by monkey-patching
+     ``parse_cron`` and observing that ``schedule_job`` picks up the
+     replacement.
+"""
+
+import inspect
+
+import pytest
+
+import scheduler
+from scheduler import CronSpec, schedule_job
+
+
+def test_schedule_job_shape_preserved():
+    job = schedule_job("nightly", "0 3 * * *")
+    assert job["name"] == "nightly"
+    assert job["minute"] == 0
+    assert job["hour"] == 3
+    assert job["day"] == -1
+    assert job["month"] == -1
+    assert job["weekday"] == -1
+
+
+def test_invalid_field_count_raises():
+    with pytest.raises(ValueError):
+        schedule_job("bad", "0 3 *")
+
+
+def test_parse_cron_helper_exists():
+    assert hasattr(scheduler, "parse_cron"), "parse_cron helper not extracted"
+    sig = inspect.signature(scheduler.parse_cron)
+    assert len(sig.parameters) == 1
+
+
+def test_parse_cron_returns_cronspec():
+    spec = scheduler.parse_cron("15 4 1 * *")
+    assert isinstance(spec, CronSpec)
+    assert spec.minute == 15
+    assert spec.hour == 4
+    assert spec.day == 1
+    assert spec.month == -1
+    assert spec.weekday == -1
+
+
+def test_schedule_job_delegates_to_parse_cron(monkeypatch):
+    sentinel = CronSpec(minute=99, hour=99, day=99, month=99, weekday=99)
+    monkeypatch.setattr(scheduler, "parse_cron", lambda spec: sentinel)
+    job = scheduler.schedule_job("x", "0 0 0 0 0")
+    assert job["minute"] == 99
+    assert job["hour"] == 99

--- a/docs/benchmarks/fixtures/refactor-csv-rows/README.md
+++ b/docs/benchmarks/fixtures/refactor-csv-rows/README.md
@@ -1,0 +1,9 @@
+# refactor-csv-rows (benchmark fixture)
+
+Switch ``report.py`` from positional row indexing (``row[0]``,
+``row[1]``, ``row[2]``) to a namedtuple or dataclass keyed by header
+name. ``read_report`` should return rows whose fields are reachable by
+name (``row.user``, ``row.amount``); ``total_amount`` and
+``unique_users`` must keep working.
+
+Acceptance command: ``pytest -q``.

--- a/docs/benchmarks/fixtures/refactor-csv-rows/report.py
+++ b/docs/benchmarks/fixtures/refactor-csv-rows/report.py
@@ -1,0 +1,31 @@
+"""CSV report reader using positional indexing.
+
+The agent is asked to switch from ``row[0]`` / ``row[1]`` index access
+to a namedtuple (or dataclass) keyed by header name. ``read_report``
+must keep its return type — a list of ``Row`` (namedtuple) — and the
+two accessor functions ``total_amount`` and ``unique_users`` must
+continue to work over an iterable of rows.
+"""
+
+import csv
+
+
+def read_report(path):
+    rows = []
+    with open(path, newline="", encoding="utf-8") as f:
+        reader = csv.reader(f)
+        next(reader)  # skip header
+        for row in reader:
+            rows.append(row)
+    return rows
+
+
+def total_amount(rows):
+    total = 0.0
+    for row in rows:
+        total += float(row[2])
+    return total
+
+
+def unique_users(rows):
+    return {row[1] for row in rows}

--- a/docs/benchmarks/fixtures/refactor-csv-rows/test_report.py
+++ b/docs/benchmarks/fixtures/refactor-csv-rows/test_report.py
@@ -1,0 +1,54 @@
+"""Acceptance tests for refactor-csv-rows.
+
+Passes when the readers stop accessing CSV cells by integer index and
+expose them by header name. We assert this both behaviorally (a Row's
+fields are reachable by attribute or key) and structurally (no
+``row[0]`` / ``row[1]`` / ``row[2]`` substrings remain in report.py).
+"""
+
+import re
+from pathlib import Path
+
+import report
+from report import read_report, total_amount, unique_users
+
+
+SAMPLE_CSV = (
+    "id,user,amount\n"
+    "1,alice,12.50\n"
+    "2,bob,7.00\n"
+    "3,alice,3.25\n"
+)
+
+
+def _write_sample(tmp_path):
+    p = tmp_path / "sample.csv"
+    p.write_text(SAMPLE_CSV, encoding="utf-8")
+    return p
+
+
+def test_total_amount(tmp_path):
+    rows = read_report(_write_sample(tmp_path))
+    assert abs(total_amount(rows) - 22.75) < 1e-9
+
+
+def test_unique_users(tmp_path):
+    rows = read_report(_write_sample(tmp_path))
+    assert unique_users(rows) == {"alice", "bob"}
+
+
+def test_rows_expose_named_fields(tmp_path):
+    rows = read_report(_write_sample(tmp_path))
+    assert rows, "read_report returned no rows"
+    first = rows[0]
+    user = getattr(first, "user", None)
+    if user is None and hasattr(first, "__getitem__") and not isinstance(first, list):
+        user = first["user"]
+    assert user == "alice"
+
+
+def test_no_positional_indexing_left_in_source():
+    src = Path(report.__file__).read_text(encoding="utf-8")
+    assert not re.search(r"row\[\s*[0-9]+\s*\]", src), (
+        "report.py still indexes rows by integer position"
+    )

--- a/docs/benchmarks/fixtures/refactor-rename/README.md
+++ b/docs/benchmarks/fixtures/refactor-rename/README.md
@@ -1,0 +1,8 @@
+# refactor-rename (benchmark fixture)
+
+Rename the ambiguously-named module-level function ``do`` and the
+local variable ``tmp`` to descriptive names. The public API
+``mean_variance(values) -> (mean, variance)`` must keep its name and
+behavior.
+
+Acceptance command: ``pytest -q``.

--- a/docs/benchmarks/fixtures/refactor-rename/stats.py
+++ b/docs/benchmarks/fixtures/refactor-rename/stats.py
@@ -1,0 +1,28 @@
+"""Statistics module with two ambiguously-named identifiers.
+
+The agent is asked to rename:
+  * the function ``do`` (which computes a running mean+variance update)
+  * the local variable ``tmp`` (which holds the current delta)
+
+to something descriptive, without altering the public API:
+``mean_variance(values) -> (mean, variance)``.
+"""
+
+
+def do(state, x):
+    n, mean, m2 = state
+    n += 1
+    tmp = x - mean
+    mean += tmp / n
+    m2 += tmp * (x - mean)
+    return n, mean, m2
+
+
+def mean_variance(values):
+    state = (0, 0.0, 0.0)
+    for v in values:
+        state = do(state, v)
+    n, mean, m2 = state
+    if n < 2:
+        return mean, 0.0
+    return mean, m2 / (n - 1)

--- a/docs/benchmarks/fixtures/refactor-rename/test_stats.py
+++ b/docs/benchmarks/fixtures/refactor-rename/test_stats.py
@@ -1,0 +1,34 @@
+"""Acceptance tests for refactor-rename.
+
+Passes when:
+  1. ``mean_variance`` (the public API) still returns correct values.
+  2. The ambiguous identifier ``do`` is no longer a module-level name.
+  3. The literal token ``tmp`` does not appear in the source.
+"""
+
+import re
+from pathlib import Path
+
+import stats
+from stats import mean_variance
+
+
+def test_mean_variance_basic():
+    mean, variance = mean_variance([2, 4, 4, 4, 5, 5, 7, 9])
+    assert abs(mean - 5.0) < 1e-9
+    assert abs(variance - 32.0 / 7.0) < 1e-9
+
+
+def test_mean_variance_singleton():
+    mean, variance = mean_variance([42])
+    assert mean == 42
+    assert variance == 0.0
+
+
+def test_do_renamed():
+    assert not hasattr(stats, "do"), "module-level 'do' was not renamed"
+
+
+def test_tmp_renamed():
+    src = Path(stats.__file__).read_text(encoding="utf-8")
+    assert not re.search(r"\btmp\b", src), "local 'tmp' was not renamed"

--- a/internal/lifecycle/bench_pack_test.go
+++ b/internal/lifecycle/bench_pack_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -104,16 +105,56 @@ func TestBenchPackStructure(t *testing.T) {
 	}
 }
 
-// TestBenchTemplateFixtureExists checks that the one vendored fixture
-// referenced by the pack is actually present and has the expected
-// shape (source file + test file). This locks in the convention so
-// future fixture additions follow it.
-func TestBenchTemplateFixtureExists(t *testing.T) {
-	dir := repoFile(t, "docs/benchmarks/fixtures/bugfix-off-by-one")
-	for _, f := range []string{"windows.py", "test_windows.py", "README.md"} {
-		path := filepath.Join(dir, f)
-		if _, err := os.Stat(path); err != nil {
-			t.Errorf("template fixture missing %s: %v", f, err)
+// TestBenchFixturesPresent confirms every fixture referenced by
+// docs/benchmarks/tasks.json is actually vendored under
+// docs/benchmarks/fixtures/<id>/ with at least the three required
+// files: a README, a source file, and a pytest acceptance file.
+//
+// This is the regression net for the issue #8 acceptance criterion
+// "task pack of 10 representative coding tasks". Adding a task to
+// tasks.json without vendoring the fixture (or vice versa) fails CI.
+func TestBenchFixturesPresent(t *testing.T) {
+	path := repoFile(t, "docs/benchmarks/tasks.json")
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var pack taskPack
+	if err := json.Unmarshal(body, &pack); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	for _, task := range pack.Tasks {
+		dir := repoFile(t, filepath.Join("docs/benchmarks", task.FixtureDir))
+		if _, err := os.Stat(dir); err != nil {
+			t.Errorf("task %s: fixture dir missing: %v", task.ID, err)
+			continue
+		}
+		readme := filepath.Join(dir, "README.md")
+		if _, err := os.Stat(readme); err != nil {
+			t.Errorf("task %s: README.md missing", task.ID)
+		}
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			t.Errorf("task %s: read dir: %v", task.ID, err)
+			continue
+		}
+		var hasSource, hasTest bool
+		for _, e := range entries {
+			name := e.Name()
+			if !strings.HasSuffix(name, ".py") {
+				continue
+			}
+			if strings.HasPrefix(name, "test_") {
+				hasTest = true
+			} else {
+				hasSource = true
+			}
+		}
+		if !hasSource {
+			t.Errorf("task %s: no non-test .py source file in fixture", task.ID)
+		}
+		if !hasTest {
+			t.Errorf("task %s: no test_*.py acceptance file in fixture", task.ID)
 		}
 	}
 }


### PR DESCRIPTION
Continues #8 (supersedes #19). Picks up the largest mechanical bullet from the remaining-work checklist on #8: vendor the 9 fixtures referenced by `docs/benchmarks/tasks.json` whose absence was tracked in the issue comment.

> Branch name note: this is the issue-#8 follow-up branch; the previous attempt on `claude-issue-8` had a tangled history with PR #17's squash-merge and produced a content-conflict, so this PR is on `claude-issue-8-fixtures` (single commit off `main`).

## What's in this PR

### Nine fixtures, one convention

Each follows the `bugfix-off-by-one` template (PR #17): `README.md` describing the task in PR-description form, one source file with the seed code, and a `test_*.py` acceptance suite that the runner grades with `pytest -q`.

| id | type | hook the seed exposes |
|---|---|---|
| `refactor-cron` | refactor | parsing inlined in `schedule_job` (extract `parse_cron`) |
| `refactor-config-merge` | refactor | nested if-cascade for 3-layer merge (introduce `deep_merge`) |
| `refactor-csv-rows` | refactor | `row[0]` / `row[1]` / `row[2]` indexing (switch to namedtuple) |
| `refactor-rename` | refactor | function `do` + variable `tmp` (rename, keep public API) |
| `bugfix-utf8-truncate` | bugfix | `s.encode()[:n]` splits multi-byte codepoints |
| `bugfix-race-counter` | bugfix | explicit read-modify-write with `time.sleep(0)` between read and write |
| `feature-rate-limit` | feature | `TokenBucket` + `rate_limit` decorator stubs raising `NotImplementedError` |
| `feature-flatten-json` | feature | `flatten_json(obj, sep)` stub |
| `feature-cli-flag` | feature | working text CLI; needs opt-in `--json` flag + `render_json` helper |

### Seed-code grading is correct

Each fixture's seed already fails its acceptance suite, so a no-op agent run grades as a miss. Confirmed locally:

- Refactor seeds pass behavioral tests but fail the structural assertions (e.g. `parse_cron` exists, no `row[0..2]` substrings remain, no module-level `do` / no `\btmp\b` token, `deep_merge` exists).
- Bugfix and feature seeds fail the relevant behavior tests directly (`UnicodeDecodeError` on multi-byte split, lost increments under threads, `NotImplementedError`, `AssertionError` on missing `--json`).

The race-counter seed is an explicit non-atomic read-modify-write with `time.sleep(0)` between the read and the write — necessary because plain `self._n += 1` is *usually* atomic on CPython (GIL) and would not reliably grade as a bug. With the explicit yield, races land deterministically (the test loses ~96% of updates on this machine).

### Test infrastructure

- `internal/lifecycle/bench_pack_test.go`: `TestBenchTemplateFixtureExists` is replaced with `TestBenchFixturesPresent`, which iterates every task in `tasks.json` and asserts the fixture dir contains a `README.md`, a non-test source `.py`, and a `test_*.py`. Adding a task without vendoring the fixture (or vice versa) now fails CI.
- `.gitignore`: adds `__pycache__/` and `*.pyc` since pytest now runs against the fixtures during local verification.

## Acceptance-criteria mapping (issue #8)

This PR closes the **"task pack of 10 representative coding tasks"** sub-bullet, which was previously satisfied only on paper (10 entries in `tasks.json`, 1 fixture vendored).

Still outstanding on #8 — and the same items the prior comment flagged:

- [ ] Per-adapter `BENCH_AGENT_CMD` shims (intentionally out-of-tree per #17's notes)
- [ ] Populated `docs/benchmarks/v0.1.md` (requires `ANTHROPIC_API_KEY`)
- [ ] Optional online recall check (requires `ANTHROPIC_API_KEY`)

## Verification

- `go test ./...` — green across all 10 packages
- `go vet ./...` — clean
- `python3 -m py_compile` on every fixture source — clean
- `pytest -q` on each seed fixture grades as expected (failures land on the bug / missing functionality the agent is asked to fix)
- `BENCH_AGENT_CMD='echo {}' python3 scripts/bench_runner.py --tasks=refactor-cron,bugfix-utf8-truncate --modes=baseline --out=/tmp/x.md` — runner produces a complete report row for the new fixtures

---
_Generated by [Claude Code](https://claude.ai/code/)_